### PR TITLE
PHPMNT-8 Add phpstan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,17 @@ orbs:
   ci: bigcommerce/internal@volatile
   php: bigcommerce/internal-php@volatile
 
+default_matrix: &default_matrix
+  matrix:
+    parameters:
+      php-version: [ "8.0", "8.1", "8.2" ]
+
 workflows:
   version: 2
   full:
     jobs:
       - php/phpunit-tests:
-          e:
-            name: php/php
-            php-version: <<matrix.php-version>>
-          matrix:
-            parameters:
-              php-version: [ "8.0" ]
+          <<: *default_matrix
+      - php/static-analysis:
+          <<: *default_matrix
+          generate_ide_helper: false

--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -1,0 +1,146 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Adapter\\\\ArrayContainerAdapter\\:\\:__construct\\(\\) has parameter \\$arrayContainer with generic interface ArrayAccess but does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: ../src/Adapter/ArrayContainerAdapter.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Adapter\\\\ArrayContainerAdapter\\:\\:__construct\\(\\) has parameter \\$arrayContainer with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Adapter/ArrayContainerAdapter.php
+
+		-
+			message: "#^Property Bigcommerce\\\\Injector\\\\Adapter\\\\ArrayContainerAdapter\\:\\:\\$arrayContainer type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Adapter/ArrayContainerAdapter.php
+
+		-
+			message: "#^Property Bigcommerce\\\\Injector\\\\Adapter\\\\ArrayContainerAdapter\\:\\:\\$arrayContainer with generic interface ArrayAccess does not specify its types\\: TKey, TValue$#"
+			count: 1
+			path: ../src/Adapter/ArrayContainerAdapter.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Cache\\\\ArrayServiceCache\\:\\:__construct\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Cache/ArrayServiceCache.php
+
+		-
+			message: "#^Property Bigcommerce\\\\Injector\\\\Cache\\\\ArrayServiceCache\\:\\:\\$values type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Cache/ArrayServiceCache.php
+
+		-
+			message: "#^Parameter \\#2 \\$code of method Exception\\:\\:__construct\\(\\) expects int, null given\\.$#"
+			count: 1
+			path: ../src/Exception/InjectorInvocationException.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:buildParameterArray\\(\\) has parameter \\$methodSignature with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:buildParameterArray\\(\\) has parameter \\$providedParameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:buildParameterArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:create\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:getAutoCreateWhiteList\\(\\) has invalid return type string\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:getAutoCreateWhiteList\\(\\) should return array\\<string\\> but returns array\\<string\\>\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:invoke\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:resolveParameter\\(\\) has parameter \\$parameterData with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:resolveParameter\\(\\) has parameter \\$providedParameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Injector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\InjectorInterface\\:\\:create\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/InjectorInterface.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\InjectorInterface\\:\\:invoke\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/InjectorInterface.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\InjectorServiceProvider\\:\\:create\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/InjectorServiceProvider.php
+
+		-
+			message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"
+			count: 1
+			path: ../src/Reflection/ParameterInspector.php
+
+		-
+			message: "#^Call to an undefined method ReflectionType\\:\\:isBuiltin\\(\\)\\.$#"
+			count: 1
+			path: ../src/Reflection/ParameterInspector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getMethodSignature\\(\\) has parameter \\$refClass with generic class ReflectionClass but does not specify its types\\: T$#"
+			count: 1
+			path: ../src/Reflection/ParameterInspector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getMethodSignature\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Reflection/ParameterInspector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getSignatureByClassName\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Reflection/ParameterInspector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getSignatureByReflectionClass\\(\\) has parameter \\$reflectionClass with generic class ReflectionClass but does not specify its types\\: T$#"
+			count: 1
+			path: ../src/Reflection/ParameterInspector.php
+
+		-
+			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getSignatureByReflectionClass\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../src/Reflection/ParameterInspector.php
+
+		-
+			message: "#^Anonymous function has an unused use \\$className\\.$#"
+			count: 1
+			path: ../src/ServiceProvider/BindingClosureFactory.php
+
+		-
+			message: "#^Parameter \\#2 \\$initializer of method ProxyManager\\\\Factory\\\\LazyLoadingValueHolderFactory\\:\\:createProxy\\(\\) expects Closure\\(object\\|null\\=, ProxyManager\\\\Proxy\\\\VirtualProxyInterface\\=, string\\=, array\\<string, mixed\\>\\=, Closure\\|null\\=\\)\\: bool, Closure\\(mixed, mixed, mixed, mixed, mixed\\)\\: true given\\.$#"
+			count: 1
+			path: ../src/ServiceProvider/BindingClosureFactory.php
+
+		-
+			message: "#^Unable to resolve the template type RealObjectType in call to method ProxyManager\\\\Factory\\\\LazyLoadingValueHolderFactory\\:\\:createProxy\\(\\)$#"
+			count: 1
+			path: ../src/ServiceProvider/BindingClosureFactory.php

--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -21,16 +21,6 @@ parameters:
 			path: ../src/Adapter/ArrayContainerAdapter.php
 
 		-
-			message: "#^Method Bigcommerce\\\\Injector\\\\Cache\\\\ArrayServiceCache\\:\\:__construct\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../src/Cache/ArrayServiceCache.php
-
-		-
-			message: "#^Property Bigcommerce\\\\Injector\\\\Cache\\\\ArrayServiceCache\\:\\:\\$values type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../src/Cache/ArrayServiceCache.php
-
-		-
 			message: "#^Parameter \\#2 \\$code of method Exception\\:\\:__construct\\(\\) expects int, null given\\.$#"
 			count: 1
 			path: ../src/Exception/InjectorInvocationException.php

--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ Dependency Injector component built on top of Pimple container.
 
 - Also includes an AutoWiring ServiceProvider. 
 
+## Local development
+### PhpStan
+To check your code with [phpstan](https://phpstan.org/), run `script/phpstan`.
+
+**Remove errors from baseline:**
+While changing the code you might see the following error from the PhpStan
+```
+Ignored error pattern #.... was not matched in reported errors.
+```
+This means that the error is [no longer present](https://phpstan.org/user-guide/ignoring-errors#reporting-unused-ignores) in the code, so you can remove it from the baseline file.
+To do so, run `./vendor/bin/phpstan --generate-baseline=.phpstan/baseline.neon` and commit the changes.
+
+## License
 (The MIT License)
 Copyright (C) 2015-2017 BigCommerce Inc.
 All rights reserved.

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.6 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-    "phpspec/prophecy-phpunit": "^2.0"
+    "phpspec/prophecy-phpunit": "^2.0",
+    "phpstan/phpstan": "^1.10"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26703924c189d1487b1bca65235e753e",
+    "content-hash": "766b759dc40821f747cc2141630920cb",
     "packages": [
         {
             "name": "laminas/laminas-code",
@@ -986,6 +986,68 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.16.1"
             },
             "time": "2023-02-07T18:11:17+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d232901b09e67538e5c86a724be841bea5768a7c",
+                "reference": "d232901b09e67538e5c86a724be841bea5768a7c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-04-19T13:47:27+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+   level: 6
+   paths:
+     - ./src
+   bootstrapFiles:
+     - ./vendor/autoload.php
+includes:
+ - .phpstan/baseline.neon

--- a/src/Cache/ArrayServiceCache.php
+++ b/src/Cache/ArrayServiceCache.php
@@ -7,13 +7,12 @@ namespace Bigcommerce\Injector\Cache;
 class ArrayServiceCache implements ServiceCacheInterface
 {
     /**
-     * @var array
+     * @var array<string, string>
      */
     private $values = [];
 
     /**
-     * ArrayCache constructor.
-     * @param array $values
+     * @param array<string, string> $values
      */
     public function __construct($values = [])
     {


### PR DESCRIPTION
## What/Why?
- [x] add phpstan

Check code with [phpstan](https://phpstan.org/)
By default, all current errors are suppressed.
We start from [level 6](https://phpstan.org/user-guide/rule-levels) and in the future may rise a bar.

- [x] Run tests under 8.0, 8.1 and 8.2 

## Testing
See circle.

## Deploy
This tool is used only in the CI environment and should not affect production.

## Useful links
PhpStan [documentation](https://phpstan.org/user-guide/getting-started)
