### PR TITLE
Fix deprecation warning

### DIFF
--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: ../src/Adapter/ArrayContainerAdapter.php
 
 		-
-			message: "#^Parameter \\#2 \\$code of method Exception\\:\\:__construct\\(\\) expects int, null given\\.$#"
-			count: 1
-			path: ../src/Exception/InjectorInvocationException.php
-
-		-
 			message: "#^Method Bigcommerce\\\\Injector\\\\Injector\\:\\:buildParameterArray\\(\\) has parameter \\$methodSignature with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../src/Injector.php

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # bigcommerce/injector 
-[![Build Status](https://travis-ci.com/bigcommerce/injector.svg?token=rXMck33q3q2Yxpxghp1G&branch=master)](https://travis-ci.com/bigcommerce/injector) 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/bigcommerce/injector/badges/quality-score.png?b=master&s=9182fe29e72cb72190270e8d2d7940048e6835e9)](https://scrutinizer-ci.com/g/bigcommerce/injector/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/bigcommerce/injector/badges/coverage.png?b=master&s=6c092242baba856ab9172b116482e21cd85c8d32)](https://scrutinizer-ci.com/g/bigcommerce/injector/?branch=master)
 
 Dependency Injector component built on top of Pimple container.
 

--- a/composer.lock
+++ b/composer.lock
@@ -1369,16 +1369,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.5",
+            "version": "9.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5"
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/86e761949019ae83f49240b2f2123fb5ab3b2fc5",
-                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
                 "shasum": ""
             },
             "require": {
@@ -1451,7 +1451,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.5"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
             },
             "funding": [
                 {
@@ -1467,7 +1468,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-09T06:34:10+00:00"
+            "time": "2023-04-14T08:58:40+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
->
-    <testsuites>
-        <testsuite name="Injector Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+         bootstrap="vendor/autoload.php">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Injector Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Exception/InjectorInvocationException.php
+++ b/src/Exception/InjectorInvocationException.php
@@ -17,6 +17,6 @@ class InjectorInvocationException extends ServiceException
      */
     public function __construct($message, Exception $previous = null)
     {
-        parent::__construct($message, null, $previous);
+        parent::__construct($message, 0, $previous);
     }
 }


### PR DESCRIPTION
#### What?
1. Fix deprecation warning
`Deprecated: Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated in injector/src/Exception/InjectorInvocationException.php on line 20`

2. Remove Scrutinizer badges from README since we no longer use this
3. Migrate phpunit.xml to new format
4. Bump phpunit. Not sure why we have composer.lock committed here really

ping @bigcommerce/php