### PR TITLE
Change from `ocramius/proxy-manager` to `friendsofphp/proxy-manager-lts`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+composer.lock
 /.phpunit.result.cache
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^7.3 || ^8.0",
     "pimple/pimple": "*",
-    "ocramius/proxy-manager": "^1.0 || ^2.0",
+    "friendsofphp/proxy-manager-lts": "^1.0",
     "psr/container": "^1.0"
   },
   "require-dev": {


### PR DESCRIPTION
## What?
Change from `ocramius/proxy-manager` to `friendsofphp/proxy-manager-lts`

## Why
`ocramius/proxy-manager` is unwilling to fix some PHP 8.1 issues. `friendsofphp/proxy-manager-lts` seem to be a like-for-like replacement.

ping @bigcommerce/php