### PR TITLE
BIG-31502 Expand reflection caching

### DIFF
--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -96,22 +96,7 @@ parameters:
 			path: ../src/Reflection/ParameterInspector.php
 
 		-
-			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getMethodSignature\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../src/Reflection/ParameterInspector.php
-
-		-
-			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getSignatureByClassName\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../src/Reflection/ParameterInspector.php
-
-		-
 			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getSignatureByReflectionClass\\(\\) has parameter \\$reflectionClass with generic class ReflectionClass but does not specify its types\\: T$#"
-			count: 1
-			path: ../src/Reflection/ParameterInspector.php
-
-		-
-			message: "#^Method Bigcommerce\\\\Injector\\\\Reflection\\\\ParameterInspector\\:\\:getSignatureByReflectionClass\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../src/Reflection/ParameterInspector.php
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^8.1",
     "pimple/pimple": "*",
     "friendsofphp/proxy-manager-lts": "^1.0",
     "psr/container": "^1.0"

--- a/src/Cache/ArrayServiceCache.php
+++ b/src/Cache/ArrayServiceCache.php
@@ -1,23 +1,22 @@
 <?php
 namespace Bigcommerce\Injector\Cache;
 
-use ArrayIterator;
 use Countable;
-use IteratorAggregate;
-use Traversable;
 
 /**
  * In process, memory array service cache.
+ * @template T
+ * @implements MultiGetCacheInterface<T>
  */
 class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface, Countable
 {
     /**
-     * @var array<string, mixed>
+     * @var array<string, T>
      */
     private array $values;
 
     /**
-     * @param array<string, mixed> $values
+     * @param array<string, T> $values
      */
     public function __construct(array $values = [])
     {
@@ -28,7 +27,7 @@ class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface
      * Retrieve the value of a key in the cache.
      *
      * @param string $key
-     * @return mixed cached value or false when key not present in a cache
+     * @return T cached value or false when key not present in a cache
      */
     public function get(string $key): mixed
     {
@@ -42,7 +41,7 @@ class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface
      * Save a key/value pair to the cache.
      *
      * @param string $key
-     * @param mixed $value
+     * @param T $value
      * @return void
      */
     public function set(string $key, mixed $value): void
@@ -78,7 +77,7 @@ class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface
     /**
      * Retrieve all entries of the cache.
      *
-     * @return array<string, mixed>
+     * @return array<string, T>
      */
     public function getAll(): array
     {

--- a/src/Cache/ArrayServiceCache.php
+++ b/src/Cache/ArrayServiceCache.php
@@ -1,20 +1,25 @@
 <?php
 namespace Bigcommerce\Injector\Cache;
 
+use ArrayIterator;
+use Countable;
+use IteratorAggregate;
+use Traversable;
+
 /**
  * In process, memory array service cache.
  */
-class ArrayServiceCache implements ServiceCacheInterface
+class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface, Countable
 {
     /**
      * @var array<string, string>
      */
-    private $values = [];
+    private array $values;
 
     /**
      * @param array<string, string> $values
      */
-    public function __construct($values = [])
+    public function __construct(array $values = [])
     {
         $this->values = $values;
     }
@@ -23,9 +28,9 @@ class ArrayServiceCache implements ServiceCacheInterface
      * Retrieve the value of a key in the cache.
      *
      * @param string $key
-     * @return string|false cached string value or false when key not present in a cache
+     * @return mixed cached string value or false when key not present in a cache
      */
-    public function get($key)
+    public function get(string $key): mixed
     {
         if (!isset($this->values[$key])) {
             return false;
@@ -37,10 +42,10 @@ class ArrayServiceCache implements ServiceCacheInterface
      * Save a key/value pair to the cache.
      *
      * @param string $key
-     * @param string $value
+     * @param mixed $value
      * @return void
      */
-    public function set($key, $value)
+    public function set(string $key, mixed $value): void
     {
         $this->values[$key] = $value;
     }
@@ -51,11 +56,26 @@ class ArrayServiceCache implements ServiceCacheInterface
      * @param string $key
      * @return void
      */
-    public function remove($key)
+    public function remove(string $key): void
     {
         if (!isset($this->values[$key])) {
             return;
         }
         unset($this->values[$key]);
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->values[$key]);
+    }
+
+    public function getAll(): array
+    {
+        return $this->values;
+    }
+
+    public function count(): int
+    {
+        return count($this->values);
     }
 }

--- a/src/Cache/ArrayServiceCache.php
+++ b/src/Cache/ArrayServiceCache.php
@@ -12,12 +12,12 @@ use Traversable;
 class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface, Countable
 {
     /**
-     * @var array<string, string>
+     * @var array<string, mixed>
      */
     private array $values;
 
     /**
-     * @param array<string, string> $values
+     * @param array<string, mixed> $values
      */
     public function __construct(array $values = [])
     {
@@ -28,7 +28,7 @@ class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface
      * Retrieve the value of a key in the cache.
      *
      * @param string $key
-     * @return mixed cached string value or false when key not present in a cache
+     * @return mixed cached value or false when key not present in a cache
      */
     public function get(string $key): mixed
     {
@@ -64,16 +64,32 @@ class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface
         unset($this->values[$key]);
     }
 
+    /**
+     * Check if a key exists in the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
     public function has(string $key): bool
     {
         return isset($this->values[$key]);
     }
 
+    /**
+     * Retrieve all entries of the cache.
+     *
+     * @return array<string, mixed>
+     */
     public function getAll(): array
     {
         return $this->values;
     }
 
+    /**
+     * Count elements of the cache.
+     *
+     * @return int
+     */
     public function count(): int
     {
         return count($this->values);

--- a/src/Cache/MultiGetCacheInterface.php
+++ b/src/Cache/MultiGetCacheInterface.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Bigcommerce\Injector\Cache;
 
+/**
+ * @template T
+ */
 interface MultiGetCacheInterface
 {
     /**
      * Retrieve all entries of the cache.
      *
-     * @return array<string, mixed>
+     * @return array<string, T>
      */
     public function getAll(): array;
 }

--- a/src/Cache/MultiGetCacheInterface.php
+++ b/src/Cache/MultiGetCacheInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigcommerce\Injector\Cache;
+
+interface MultiGetCacheInterface
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getAll(): array;
+}

--- a/src/Cache/MultiGetCacheInterface.php
+++ b/src/Cache/MultiGetCacheInterface.php
@@ -7,7 +7,9 @@ namespace Bigcommerce\Injector\Cache;
 interface MultiGetCacheInterface
 {
     /**
-     * @return array<string, string>
+     * Retrieve all entries of the cache.
+     *
+     * @return array<string, mixed>
      */
     public function getAll(): array;
 }

--- a/src/Cache/NoOpServiceCache.php
+++ b/src/Cache/NoOpServiceCache.php
@@ -10,9 +10,9 @@ class NoOpServiceCache implements ServiceCacheInterface
      * Retrieve the value of a key in the cache.
      *
      * @param string $key
-     * @return string|false cached string value or false when key not present in a cache
+     * @return mixed|false cached string value or false when key not present in a cache
      */
-    public function get($key)
+    public function get(string $key): mixed
     {
         return false;
     }
@@ -21,10 +21,10 @@ class NoOpServiceCache implements ServiceCacheInterface
      * Save a key/value pair to the cache.
      *
      * @param string $key
-     * @param string $value
+     * @param mixed $value
      * @return void
      */
-    public function set($key, $value)
+    public function set(string $key, mixed $value): void
     {
         return;
     }
@@ -35,8 +35,13 @@ class NoOpServiceCache implements ServiceCacheInterface
      * @param string $key
      * @return void
      */
-    public function remove($key)
+    public function remove(string $key): void
     {
         return;
+    }
+
+    public function has(string $key): bool
+    {
+        return false;
     }
 }

--- a/src/Cache/NoOpServiceCache.php
+++ b/src/Cache/NoOpServiceCache.php
@@ -40,6 +40,12 @@ class NoOpServiceCache implements ServiceCacheInterface
         return;
     }
 
+    /**
+     * Check if a key exists in the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
     public function has(string $key): bool
     {
         return false;

--- a/src/Cache/ServiceCacheInterface.php
+++ b/src/Cache/ServiceCacheInterface.php
@@ -28,6 +28,12 @@ interface ServiceCacheInterface
      */
     public function set(string $key, mixed $value);
 
+    /**
+     * Check if a key exists in the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
     public function has(string $key): bool;
 
     /**

--- a/src/Cache/ServiceCacheInterface.php
+++ b/src/Cache/ServiceCacheInterface.php
@@ -17,7 +17,7 @@ interface ServiceCacheInterface
      * @param string $key
      * @return mixed|false cached value or false when key not present in a cache
      */
-    public function get($key);
+    public function get(string $key): mixed;
 
     /**
      * Save a key/value pair to the cache.
@@ -26,7 +26,9 @@ interface ServiceCacheInterface
      * @param mixed $value
      * @return void
      */
-    public function set($key, $value);
+    public function set(string $key, mixed $value);
+
+    public function has(string $key): bool;
 
     /**
      * Remove a key from the cache.
@@ -34,5 +36,5 @@ interface ServiceCacheInterface
      * @param string $key
      * @return void
      */
-    public function remove($key);
+    public function remove(string $key): void;
 }

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -28,8 +28,6 @@ use ReflectionException;
  */
 class Injector implements InjectorInterface
 {
-    private ContainerInterface $container;
-
     /**
      * Regular Expressions matching dependencies that can be automatically created using their class name, even if they
      * are not defined in the IoC Container.
@@ -38,12 +36,8 @@ class Injector implements InjectorInterface
      */
     protected $autoCreateWhiteList = [];
 
-    private ClassInspectorInterface $classInspector;
-
-    public function __construct(ContainerInterface $container, ClassInspectorInterface $classInspector)
+    public function __construct(private ContainerInterface $container, private ClassInspectorInterface $classInspector)
     {
-        $this->container = $container;
-        $this->classInspector = $classInspector;
     }
 
     /**

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -3,8 +3,10 @@ namespace Bigcommerce\Injector;
 
 use Bigcommerce\Injector\Exception\InjectorInvocationException;
 use Bigcommerce\Injector\Exception\MissingRequiredParameterException;
-use Bigcommerce\Injector\Reflection\ParameterInspector;
+use Bigcommerce\Injector\Reflection\ClassInspector;
+use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
+use ReflectionException;
 
 /**
  * The Injector provides instantiation of objects (or invocation of methods) within the BC application and
@@ -26,10 +28,7 @@ use Psr\Container\ContainerInterface;
  */
 class Injector implements InjectorInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+    private ContainerInterface $container;
 
     /**
      * Regular Expressions matching dependencies that can be automatically created using their class name, even if they
@@ -39,20 +38,12 @@ class Injector implements InjectorInterface
      */
     protected $autoCreateWhiteList = [];
 
-    /**
-     * @var ParameterInspector
-     */
-    private $inspector;
+    private ClassInspector $classInspector;
 
-    /**
-     *
-     * @param ContainerInterface $container
-     * @param ParameterInspector $inspector
-     */
-    public function __construct(ContainerInterface $container, ParameterInspector $inspector)
+    public function __construct(ContainerInterface $container, ClassInspector $classInspector)
     {
         $this->container = $container;
-        $this->inspector = $inspector;
+        $this->classInspector = $classInspector;
     }
 
     /**
@@ -68,29 +59,27 @@ class Injector implements InjectorInterface
      * @param array $parameters An optional array of additional parameters to pass to the created objects constructor.
      * @return object
      * @throws InjectorInvocationException
-     * @throws \InvalidArgumentException
-     * @throws \ReflectionException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     public function create($className, $parameters = [])
     {
-        $reflectionClass = new \ReflectionClass($className);
-        if (!$reflectionClass->hasMethod("__construct")) {
-            //This class doesn't have a constructor
-            return $reflectionClass->newInstanceWithoutConstructor();
+        if (!$this->classInspector->classHasMethod($className, '__construct')) {
+            return new $className();
         }
-        if (!$reflectionClass->getMethod('__construct')->isPublic()) {
+
+        if (!$this->classInspector->methodIsPublic($className, '__construct')) {
             throw new InjectorInvocationException(
                 "Injector failed to create $className - constructor isn't public." .
                 " Do you need to use a static factory method instead?"
             );
         }
-        try {
-            $parameters = $this->buildParameterArray(
-                $this->inspector->getSignatureByReflectionClass($reflectionClass, "__construct"),
-                $parameters
-            );
 
-            return $reflectionClass->newInstanceArgs($parameters);
+        try {
+            $signature = $this->classInspector->getMethodSignature($className, '__construct');
+            $parameters = $this->buildParameterArray($signature, $parameters);
+
+            return new $className(...$parameters);
         } catch (MissingRequiredParameterException $e) {
             throw new InjectorInvocationException(
                 "Can't create $className " .
@@ -122,19 +111,19 @@ class Injector implements InjectorInterface
      * @param array $parameters
      * @return mixed
      * @throws InjectorInvocationException
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function invoke($instance, $methodName, $parameters = [])
     {
         if (!is_object($instance)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "Attempted Injector::invoke on a non-object: " . gettype($instance) . "."
             );
         }
         $className = get_class($instance);
         try {
             $parameters = $this->buildParameterArray(
-                $this->inspector->getSignatureByClassName($className, $methodName),
+                $this->classInspector->getMethodSignature($className, $methodName),
                 $parameters
             );
 
@@ -145,7 +134,7 @@ class Injector implements InjectorInterface
                 " - missing parameter '" . $e->getParameterString() . "'" .
                 " could not be found. Either register it as a service or pass it to invoke via parameters."
             );
-        } catch (\ReflectionException $e) {
+        } catch (ReflectionException $e) {
             throw new InjectorInvocationException(
                 "Failed to invoke $className::$methodName - method doesn't exist."
             );
@@ -197,8 +186,8 @@ class Injector implements InjectorInterface
      * @return array
      * @throws InjectorInvocationException
      * @throws MissingRequiredParameterException
-     * @throws \InvalidArgumentException
-     * @throws \ReflectionException
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     private function buildParameterArray($methodSignature, $providedParameters)
     {

--- a/src/Injector.php
+++ b/src/Injector.php
@@ -3,7 +3,7 @@ namespace Bigcommerce\Injector;
 
 use Bigcommerce\Injector\Exception\InjectorInvocationException;
 use Bigcommerce\Injector\Exception\MissingRequiredParameterException;
-use Bigcommerce\Injector\Reflection\ClassInspector;
+use Bigcommerce\Injector\Reflection\ClassInspectorInterface;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use ReflectionException;
@@ -38,9 +38,9 @@ class Injector implements InjectorInterface
      */
     protected $autoCreateWhiteList = [];
 
-    private ClassInspector $classInspector;
+    private ClassInspectorInterface $classInspector;
 
-    public function __construct(ContainerInterface $container, ClassInspector $classInspector)
+    public function __construct(ContainerInterface $container, ClassInspectorInterface $classInspector)
     {
         $this->container = $container;
         $this->classInspector = $classInspector;

--- a/src/InjectorFactory.php
+++ b/src/InjectorFactory.php
@@ -13,13 +13,13 @@ use Psr\Container\ContainerInterface;
 
 class InjectorFactory
 {
-    public static function create(ContainerInterface $container): InjectorInterface
+    public static function create(ContainerInterface $container, int $reflectionClassCacheSize = 50): InjectorInterface
     {
         $classInspector = new ClassInspector(
-            new ReflectionClassCache(50),
+            new ReflectionClassCache($reflectionClassCacheSize),
             new ParameterInspector(),
             new ArrayServiceCache(),
-            new ClassInspectorStats()
+            new ClassInspectorStats(),
         );
 
         return new Injector($container, $classInspector);

--- a/src/InjectorFactory.php
+++ b/src/InjectorFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bigcommerce\Injector;
 
 use Bigcommerce\Injector\Cache\ArrayServiceCache;
+use Bigcommerce\Injector\Reflection\CachingClassInspector;
 use Bigcommerce\Injector\Reflection\ClassInspector;
 use Bigcommerce\Injector\Reflection\ClassInspectorStats;
 use Bigcommerce\Injector\Reflection\ParameterInspector;
@@ -18,10 +19,14 @@ class InjectorFactory
         $classInspector = new ClassInspector(
             new ReflectionClassCache($reflectionClassCacheSize),
             new ParameterInspector(),
-            new ArrayServiceCache(),
             new ClassInspectorStats(),
         );
 
-        return new Injector($container, $classInspector);
+        $cachingClassInspector = new CachingClassInspector(
+            $classInspector,
+            new ArrayServiceCache(),
+        );
+
+        return new Injector($container, $cachingClassInspector);
     }
 }

--- a/src/InjectorFactory.php
+++ b/src/InjectorFactory.php
@@ -8,7 +8,7 @@ use Bigcommerce\Injector\Cache\ArrayServiceCache;
 use Bigcommerce\Injector\Reflection\ClassInspector;
 use Bigcommerce\Injector\Reflection\ClassInspectorStats;
 use Bigcommerce\Injector\Reflection\ParameterInspector;
-use Bigcommerce\Injector\Reflection\ReflectionClassMap;
+use Bigcommerce\Injector\Reflection\ReflectionClassCache;
 use Psr\Container\ContainerInterface;
 
 class InjectorFactory
@@ -16,7 +16,7 @@ class InjectorFactory
     public static function create(ContainerInterface $container): InjectorInterface
     {
         $classInspector = new ClassInspector(
-            new ReflectionClassMap(50),
+            new ReflectionClassCache(50),
             new ParameterInspector(),
             new ArrayServiceCache(),
             new ClassInspectorStats()

--- a/src/InjectorFactory.php
+++ b/src/InjectorFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigcommerce\Injector;
+
+use Bigcommerce\Injector\Cache\ArrayServiceCache;
+use Bigcommerce\Injector\Reflection\ClassInspector;
+use Bigcommerce\Injector\Reflection\ClassInspectorStats;
+use Bigcommerce\Injector\Reflection\ParameterInspector;
+use Bigcommerce\Injector\Reflection\ReflectionClassMap;
+use Psr\Container\ContainerInterface;
+
+class InjectorFactory
+{
+    public static function create(ContainerInterface $container): InjectorInterface
+    {
+        $classInspector = new ClassInspector(
+            new ReflectionClassMap(50),
+            new ParameterInspector(),
+            new ArrayServiceCache(),
+            new ClassInspectorStats()
+        );
+
+        return new Injector($container, $classInspector);
+    }
+}

--- a/src/Reflection/CachingClassInspector.php
+++ b/src/Reflection/CachingClassInspector.php
@@ -44,14 +44,14 @@ class CachingClassInspector implements ClassInspectorInterface
     public function classHasMethod(string $class, string $method): bool
     {
         $key = "$class::{$method}::exists";
-        if ($this->serviceCache->has($key)) {
-            return $this->serviceCache->get($key);
+        if (!$this->serviceCache->has($key)) {
+            $this->serviceCache->set(
+                $key,
+                $this->classInspector->classHasMethod($class, $method),
+            );
         }
 
-        $methodExists = $this->classInspector->classHasMethod($class, $method);;
-        $this->serviceCache->set($key, $methodExists);
-
-        return $methodExists;
+        return $this->serviceCache->get($key);
     }
 
     /**
@@ -65,14 +65,14 @@ class CachingClassInspector implements ClassInspectorInterface
     public function methodIsPublic(string $class, string $method): bool
     {
         $key = "$class::{$method}::is_public";
-        if ($this->serviceCache->has($key)) {
-            return $this->serviceCache->get($key);
+        if (!$this->serviceCache->has($key)) {
+            $this->serviceCache->set(
+                $key,
+                $this->classInspector->methodIsPublic($class, $method),
+            );
         }
 
-        $methodIsPublic =  $this->classInspector->methodIsPublic($class, $method);;
-        $this->serviceCache->set($key, $methodIsPublic);
-
-        return $methodIsPublic;
+        return $this->serviceCache->get($key);
     }
 
     /**
@@ -86,14 +86,14 @@ class CachingClassInspector implements ClassInspectorInterface
     public function getMethodSignature(string $class, string $method): array
     {
         $key = "$class::{$method}::signature";
-        if ($this->serviceCache->has($key)) {
-            return $this->serviceCache->get($key);
+        if (!$this->serviceCache->has($key)) {
+            $this->serviceCache->set(
+                $key,
+                $this->classInspector->getMethodSignature($class, $method),
+            );
         }
 
-        $methodSignature = $this->classInspector->getMethodSignature($class, $method);;
-        $this->serviceCache->set($key, $methodSignature);
-
-        return $methodSignature;
+        return $this->serviceCache->get($key);
     }
 
     public function getStats(): ClassInspectorStats

--- a/src/Reflection/CachingClassInspector.php
+++ b/src/Reflection/CachingClassInspector.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigcommerce\Injector\Reflection;
+
+use Bigcommerce\Injector\Cache\ServiceCacheInterface;
+use ReflectionClass;
+use ReflectionException;
+
+class CachingClassInspector implements ClassInspectorInterface
+{
+    public function __construct(
+        private readonly ClassInspector $classInspector,
+        private readonly ServiceCacheInterface $serviceCache,
+    ) {
+    }
+
+    /**
+     * Warm up the cache for the given class and method.
+     *
+     * @param string $class
+     * @param string $method
+     * @return void
+     * @throws ReflectionException
+     */
+    public function warmCache(string $class, string $method): void
+    {
+        if ($this->classHasMethod($class, $method)) {
+            if ($this->methodIsPublic($class, $method)) {
+                $this->getMethodSignature($class, $method);
+            }
+        }
+    }
+
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return bool The reflection class instance for the given class.
+     * @throws ReflectionException
+     */
+    public function classHasMethod(string $class, string $method): bool
+    {
+        $key = "$class::{$method}::exists";
+        if ($this->serviceCache->has($key)) {
+            return $this->serviceCache->get($key);
+        }
+
+        $methodExists = $this->classInspector->classHasMethod($class, $method);;
+        $this->serviceCache->set($key, $methodExists);
+
+        return $methodExists;
+    }
+
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return bool The reflection class instance for the given class.
+     * @throws ReflectionException
+     */
+    public function methodIsPublic(string $class, string $method): bool
+    {
+        $key = "$class::{$method}::is_public";
+        if ($this->serviceCache->has($key)) {
+            return $this->serviceCache->get($key);
+        }
+
+        $methodIsPublic =  $this->classInspector->methodIsPublic($class, $method);;
+        $this->serviceCache->set($key, $methodIsPublic);
+
+        return $methodIsPublic;
+    }
+
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return array{'name': string, 'type'?: string, 'default'?: mixed, 'variadic'?: bool}[]
+     * @throws ReflectionException
+     */
+    public function getMethodSignature(string $class, string $method): array
+    {
+        $key = "$class::{$method}::signature";
+        if ($this->serviceCache->has($key)) {
+            return $this->serviceCache->get($key);
+        }
+
+        $methodSignature = $this->classInspector->getMethodSignature($class, $method);;
+        $this->serviceCache->set($key, $methodSignature);
+
+        return $methodSignature;
+    }
+
+    public function getStats(): ClassInspectorStats
+    {
+        return $this->classInspector->getStats();
+    }
+}

--- a/src/Reflection/ClassInspector.php
+++ b/src/Reflection/ClassInspector.php
@@ -4,33 +4,16 @@ declare(strict_types=1);
 
 namespace Bigcommerce\Injector\Reflection;
 
-use Bigcommerce\Injector\Cache\ServiceCacheInterface;
 use ReflectionClass;
 use ReflectionException;
 
-class ClassInspector
+class ClassInspector implements ClassInspectorInterface
 {
     public function __construct(
         private readonly ReflectionClassCache $reflectionClassCache,
         private readonly ParameterInspector $parameterInspector,
-        private readonly ServiceCacheInterface $serviceCache,
         private readonly ClassInspectorStats $stats
     ) {
-    }
-
-    /**
-     * @param string $class
-     * @param string $method
-     * @return void
-     * @throws ReflectionException
-     */
-    public function inspectMethod(string $class, string $method): void
-    {
-        if ($this->classHasMethod($class, $method)) {
-            if ($this->methodIsPublic($class, $method)) {
-                $this->getMethodSignature($class, $method);
-            }
-        }
     }
 
     /**
@@ -43,15 +26,7 @@ class ClassInspector
      */
     public function classHasMethod(string $class, string $method): bool
     {
-        $key = "$class::{$method}::exists";
-        if ($this->serviceCache->has($key)) {
-            return $this->serviceCache->get($key);
-        }
-
-        $methodExists = $this->getReflectionClass($class)->hasMethod($method);
-        $this->serviceCache->set($key, $methodExists);
-
-        return $methodExists;
+        return $this->getReflectionClass($class)->hasMethod($method);
     }
 
     /**
@@ -64,15 +39,7 @@ class ClassInspector
      */
     public function methodIsPublic(string $class, string $method): bool
     {
-        $key = "$class::{$method}::is_public";
-        if ($this->serviceCache->has($key)) {
-            return $this->serviceCache->get($key);
-        }
-
-        $methodIsPublic = $this->getReflectionClass($class)->getMethod($method)->isPublic();
-        $this->serviceCache->set($key, $methodIsPublic);
-
-        return $methodIsPublic;
+        return $this->getReflectionClass($class)->getMethod($method)->isPublic();
     }
 
     /**
@@ -85,16 +52,9 @@ class ClassInspector
      */
     public function getMethodSignature(string $class, string $method): array
     {
-        $key = "$class::{$method}::signature";
-        if ($this->serviceCache->has($key)) {
-            return $this->serviceCache->get($key);
-        }
-
         $reflectionClass = $this->getReflectionClass($class);
-        $methodSignature = $this->parameterInspector->getSignatureByReflectionClass($reflectionClass, $method);
-        $this->serviceCache->set($key, $methodSignature);
 
-        return $methodSignature;
+        return $this->parameterInspector->getSignatureByReflectionClass($reflectionClass, $method);
     }
 
     public function getStats(): ClassInspectorStats

--- a/src/Reflection/ClassInspector.php
+++ b/src/Reflection/ClassInspector.php
@@ -10,21 +10,12 @@ use ReflectionException;
 
 class ClassInspector
 {
-    private ReflectionClassMap $reflectionClassMap;
-    private ParameterInspector $parameterInspector;
-    private ServiceCacheInterface $serviceCache;
-    private ClassInspectorStats $stats;
-
     public function __construct(
-        ReflectionClassMap $reflectionClassMap,
-        ParameterInspector $parameterInspector,
-        ServiceCacheInterface $serviceCache,
-        ClassInspectorStats $stats
+        private readonly ReflectionClassCache $reflectionClassCache,
+        private readonly ParameterInspector $parameterInspector,
+        private readonly ServiceCacheInterface $serviceCache,
+        private readonly ClassInspectorStats $stats
     ) {
-        $this->reflectionClassMap = $reflectionClassMap;
-        $this->parameterInspector = $parameterInspector;
-        $this->serviceCache = $serviceCache;
-        $this->stats = $stats;
     }
 
     /**
@@ -122,12 +113,12 @@ class ClassInspector
      */
     private function getReflectionClass(string $class): ReflectionClass
     {
-        if ($this->reflectionClassMap->has($class)) {
-            $reflectionClass = $this->reflectionClassMap->get($class);
+        if ($this->reflectionClassCache->has($class)) {
+            $reflectionClass = $this->reflectionClassCache->get($class);
         } else {
             $reflectionClass = new ReflectionClass($class);
             $this->stats->incrementReflectionClassesCreated();
-            $this->reflectionClassMap->put($reflectionClass);
+            $this->reflectionClassCache->put($reflectionClass);
         }
 
         return $reflectionClass;

--- a/src/Reflection/ClassInspector.php
+++ b/src/Reflection/ClassInspector.php
@@ -106,6 +106,11 @@ class ClassInspector
         return $methodSignature;
     }
 
+    public function getStats(): ClassInspectorStats
+    {
+        return $this->stats;
+    }
+
     /**
      * Gets a ReflectionClass instance for the given class name.
      *

--- a/src/Reflection/ClassInspector.php
+++ b/src/Reflection/ClassInspector.php
@@ -43,7 +43,7 @@ class ClassInspector
      */
     public function classHasMethod(string $class, string $method): bool
     {
-        $key = "$class::{$method}_exists";
+        $key = "$class::{$method}::exists";
         if ($this->serviceCache->has($key)) {
             return $this->serviceCache->get($key);
         }
@@ -64,7 +64,7 @@ class ClassInspector
      */
     public function methodIsPublic(string $class, string $method): bool
     {
-        $key = "$class::{$method}_is_public";
+        $key = "$class::{$method}::is_public";
         if ($this->serviceCache->has($key)) {
             return $this->serviceCache->get($key);
         }
@@ -85,7 +85,7 @@ class ClassInspector
      */
     public function getMethodSignature(string $class, string $method): array
     {
-        $key = "$class::{$method}_signature";
+        $key = "$class::{$method}::signature";
         if ($this->serviceCache->has($key)) {
             return $this->serviceCache->get($key);
         }

--- a/src/Reflection/ClassInspector.php
+++ b/src/Reflection/ClassInspector.php
@@ -89,7 +89,7 @@ class ClassInspector
      * @param string $class
      * @param class-string<T> $class
      * @param string $method
-     * @return array<string,mixed>
+     * @return array{'name': string, 'type'?: string, 'default'?: mixed, 'variadic'?: bool}[]
      * @throws ReflectionException
      */
     public function getMethodSignature(string $class, string $method): array

--- a/src/Reflection/ClassInspector.php
+++ b/src/Reflection/ClassInspector.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigcommerce\Injector\Reflection;
+
+use Bigcommerce\Injector\Cache\ServiceCacheInterface;
+use ReflectionClass;
+use ReflectionException;
+
+class ClassInspector
+{
+    private ReflectionClassMap $reflectionClassMap;
+    private ParameterInspector $parameterInspector;
+    private ServiceCacheInterface $serviceCache;
+    private ClassInspectorStats $stats;
+
+    public function __construct(
+        ReflectionClassMap $reflectionClassMap,
+        ParameterInspector $parameterInspector,
+        ServiceCacheInterface $serviceCache,
+        ClassInspectorStats $stats
+    ) {
+        $this->reflectionClassMap = $reflectionClassMap;
+        $this->parameterInspector = $parameterInspector;
+        $this->serviceCache = $serviceCache;
+        $this->stats = $stats;
+    }
+
+    /**
+     * @param string $class
+     * @param string $method
+     * @return void
+     * @throws ReflectionException
+     */
+    public function inspectMethod(string $class, string $method): void
+    {
+        if ($this->classHasMethod($class, $method)) {
+            if ($this->methodIsPublic($class, $method)) {
+                $this->getMethodSignature($class, $method);
+            }
+        }
+    }
+
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return bool The reflection class instance for the given class.
+     * @throws ReflectionException
+     */
+    public function classHasMethod(string $class, string $method): bool
+    {
+        $key = "$class::{$method}_exists";
+        if ($this->serviceCache->has($key)) {
+            return $this->serviceCache->get($key);
+        }
+
+        $methodExists = $this->getReflectionClass($class)->hasMethod($method);
+        $this->serviceCache->set($key, $methodExists);
+
+        return $methodExists;
+    }
+
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return bool The reflection class instance for the given class.
+     * @throws ReflectionException
+     */
+    public function methodIsPublic(string $class, string $method): bool
+    {
+        $key = "$class::{$method}_is_public";
+        if ($this->serviceCache->has($key)) {
+            return $this->serviceCache->get($key);
+        }
+
+        $methodIsPublic = $this->getReflectionClass($class)->getMethod($method)->isPublic();
+        $this->serviceCache->set($key, $methodIsPublic);
+
+        return $methodIsPublic;
+    }
+
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return array<string,mixed>
+     * @throws ReflectionException
+     */
+    public function getMethodSignature(string $class, string $method): array
+    {
+        $key = "$class::{$method}_signature";
+        if ($this->serviceCache->has($key)) {
+            return $this->serviceCache->get($key);
+        }
+
+        $reflectionClass = $this->getReflectionClass($class);
+        $methodSignature = $this->parameterInspector->getSignatureByReflectionClass($reflectionClass, $method);
+        $this->serviceCache->set($key, $methodSignature);
+
+        return $methodSignature;
+    }
+
+    /**
+     * Gets a ReflectionClass instance for the given class name.
+     *
+     * @template T of object
+     * @param string $class The name of the class to reflect.
+     * @phpstan-param class-string<T> $class The name of the class to reflect.
+     * @return ReflectionClass<T> The reflection class instance for the given class.
+     * @throws ReflectionException
+     */
+    private function getReflectionClass(string $class): ReflectionClass
+    {
+        if ($this->reflectionClassMap->has($class)) {
+            $reflectionClass = $this->reflectionClassMap->get($class);
+        } else {
+            $reflectionClass = new ReflectionClass($class);
+            $this->stats->incrementReflectionClassesCreated();
+            $this->reflectionClassMap->put($reflectionClass);
+        }
+
+        return $reflectionClass;
+    }
+}

--- a/src/Reflection/ClassInspectorInterface.php
+++ b/src/Reflection/ClassInspectorInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigcommerce\Injector\Reflection;
+
+use ReflectionException;
+
+interface ClassInspectorInterface
+{
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return bool The reflection class instance for the given class.
+     * @throws ReflectionException
+     */
+    public function classHasMethod(string $class, string $method): bool;
+
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return bool The reflection class instance for the given class.
+     * @throws ReflectionException
+     */
+    public function methodIsPublic(string $class, string $method): bool;
+
+    /**
+     * @template T of object
+     * @param string $class
+     * @param class-string<T> $class
+     * @param string $method
+     * @return array{'name': string, 'type'?: string, 'default'?: mixed, 'variadic'?: bool}[]
+     * @throws ReflectionException
+     */
+    public function getMethodSignature(string $class, string $method): array;
+
+    public function getStats(): ClassInspectorStats;
+}

--- a/src/Reflection/ClassInspectorStats.php
+++ b/src/Reflection/ClassInspectorStats.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigcommerce\Injector\Reflection;
+
+class ClassInspectorStats
+{
+    private int $reflectionClassesCreated = 0;
+
+    public function incrementReflectionClassesCreated(): void
+    {
+        $this->reflectionClassesCreated++;
+    }
+
+    public function getReflectionClassesCreated(): int
+    {
+        return $this->reflectionClassesCreated;
+    }
+
+    public function reset(): void
+    {
+        $this->reflectionClassesCreated = 0;
+    }
+}

--- a/src/Reflection/ParameterInspector.php
+++ b/src/Reflection/ParameterInspector.php
@@ -1,8 +1,6 @@
 <?php
 namespace Bigcommerce\Injector\Reflection;
 
-use Bigcommerce\Injector\Cache\ServiceCacheInterface;
-
 /**
  * The ParameterInspector exposes cached reflection of a methods signature enabling auto-wiring of dependencies within
  * the Injector. This class does expose the \ReflectionParameter or utilise Parameter value objects but
@@ -14,20 +12,6 @@ use Bigcommerce\Injector\Cache\ServiceCacheInterface;
  */
 class ParameterInspector
 {
-    /**
-     * @var ServiceCacheInterface
-     */
-    private $cache;
-
-    /**
-     * ParameterInspector constructor.
-     * @param ServiceCacheInterface $cache
-     */
-    public function __construct(ServiceCacheInterface $cache)
-    {
-        $this->cache = $cache;
-    }
-
     /**
      * Fetch the method signature of a method when we have already created a \ReflectionClass
      * @param \ReflectionClass $reflectionClass
@@ -67,16 +51,11 @@ class ParameterInspector
     private function getMethodSignature($className, $methodName, \ReflectionClass $refClass = null)
     {
         $cacheKey = $className . "::" . $methodName;
-        $methodSignature = $this->cache->get($cacheKey);
-        if ($methodSignature) {
-            return $methodSignature;
-        }
         if (!$refClass) {
             $refClass = new \ReflectionClass($className);
         }
 
         $methodSignature = [];
-        $method = null;
         try {
             $method = $refClass->getMethod($methodName);
             foreach ($method->getParameters() as $parameter) {
@@ -102,7 +81,6 @@ class ParameterInspector
                 throw $e;
             }
         }
-        $this->cache->set($cacheKey, $methodSignature);
         return $methodSignature;
     }
 }

--- a/src/Reflection/ParameterInspector.php
+++ b/src/Reflection/ParameterInspector.php
@@ -50,7 +50,6 @@ class ParameterInspector
      */
     private function getMethodSignature($className, $methodName, \ReflectionClass $refClass = null)
     {
-        $cacheKey = $className . "::" . $methodName;
         if (!$refClass) {
             $refClass = new \ReflectionClass($className);
         }

--- a/src/Reflection/ParameterInspector.php
+++ b/src/Reflection/ParameterInspector.php
@@ -16,7 +16,7 @@ class ParameterInspector
      * Fetch the method signature of a method when we have already created a \ReflectionClass
      * @param \ReflectionClass $reflectionClass
      * @param string $methodName
-     * @return array
+     * @return array{'name': string, 'type'?: string, 'default'?: mixed, 'variadic'?: bool}[]
      * @throws \ReflectionException
      */
     public function getSignatureByReflectionClass(\ReflectionClass $reflectionClass, $methodName)
@@ -29,7 +29,7 @@ class ParameterInspector
      * Fetch the method signature of a method using its fully qualified class name, and method name.
      * @param string $className
      * @param string $methodName
-     * @return array
+     * @return array{'name': string, 'type'?: string, 'default'?: mixed, 'variadic'?: bool}[]
      * @throws \ReflectionException
      */
     public function getSignatureByClassName($className, $methodName)
@@ -45,7 +45,8 @@ class ParameterInspector
      * @param string $className Fully qualified class name
      * @param string $methodName Name of the method we're inspecting
      * @param \ReflectionClass $refClass Optional existing ReflectionClass for this class
-     * @return array The signature of this methods parameters as an array.
+     * @return array{'name': string, 'type'?: string, 'default'?: mixed, 'variadic'?: bool}[] The signature
+     * of this methods parameters as an array.
      * @throws \ReflectionException
      */
     private function getMethodSignature($className, $methodName, \ReflectionClass $refClass = null)

--- a/src/Reflection/ReflectionClassCache.php
+++ b/src/Reflection/ReflectionClassCache.php
@@ -7,7 +7,7 @@ namespace Bigcommerce\Injector\Reflection;
 use Countable;
 use ReflectionClass;
 
-class ReflectionClassMap implements Countable
+class ReflectionClassCache implements Countable
 {
     private int $maxSize;
 
@@ -50,13 +50,13 @@ class ReflectionClassMap implements Countable
         return isset($this->map[$className]);
     }
 
-    private function evictOneObject(): void
-    {
-        array_shift($this->map);
-    }
-
     public function count(): int
     {
         return count($this->map);
+    }
+
+    private function evictOneObject(): void
+    {
+        array_shift($this->map);
     }
 }

--- a/src/Reflection/ReflectionClassMap.php
+++ b/src/Reflection/ReflectionClassMap.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bigcommerce\Injector\Reflection;
+
+use Countable;
+use ReflectionClass;
+
+class ReflectionClassMap implements Countable
+{
+    private int $maxSize;
+
+    /**
+     * @var ReflectionClass<object>[]
+     */
+    private array $map = [];
+
+    public function __construct(int $maxSize)
+    {
+        $this->maxSize = $maxSize;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     * @return void
+     *
+     * @phpstan-param ReflectionClass<object> $reflection
+     */
+    public function put(ReflectionClass $reflection): void
+    {
+        if (count($this->map) >= $this->maxSize) {
+            $this->evictOneObject();
+        }
+        $this->map[$reflection->getName()] = $reflection;
+    }
+
+    /**
+     * @param string $className
+     * @return ReflectionClass<object>|null
+     */
+    public function get(string $className): ?ReflectionClass
+    {
+        if (isset($this->map[$className])) {
+            return $this->map[$className];
+        }
+        return null;
+    }
+
+    public function has(string $className): bool
+    {
+        return isset($this->map[$className]);
+    }
+
+    private function evictOneObject(): void
+    {
+        array_shift($this->map);
+    }
+
+    public function count(): int
+    {
+        return count($this->map);
+    }
+}

--- a/src/Reflection/ReflectionClassMap.php
+++ b/src/Reflection/ReflectionClassMap.php
@@ -24,8 +24,6 @@ class ReflectionClassMap implements Countable
     /**
      * @param ReflectionClass<object> $reflection
      * @return void
-     *
-     * @phpstan-param ReflectionClass<object> $reflection
      */
     public function put(ReflectionClass $reflection): void
     {

--- a/tests/Cache/ArrayServiceCacheTest.php
+++ b/tests/Cache/ArrayServiceCacheTest.php
@@ -38,6 +38,7 @@ class ArrayServiceCacheTest extends TestCase
         $cache->remove("test");
         $this->assertFalse($cache->get("test"));
     }
+
     public function testRemove()
     {
         $cache = new ArrayServiceCache();
@@ -45,5 +46,13 @@ class ArrayServiceCacheTest extends TestCase
         $this->assertEquals("Abc", $cache->get("test"));
         $cache->remove("test");
         $this->assertFalse($cache->get("test"));
+    }
+
+    public function testGetAll(): void
+    {
+        $cache = new ArrayServiceCache();
+        $cache->set("test1", 123);
+        $cache->set("test2", 456);
+        $this->assertEquals(['test1' => 123, 'test2' => 456], $cache->getAll());
     }
 }

--- a/tests/Cache/ArrayServiceCacheTest.php
+++ b/tests/Cache/ArrayServiceCacheTest.php
@@ -48,11 +48,45 @@ class ArrayServiceCacheTest extends TestCase
         $this->assertFalse($cache->get("test"));
     }
 
-    public function testGetAll(): void
+    public function testHasReturnsTrueForExistingKey(): void
+    {
+        $cache = new ArrayServiceCache();
+        $cache->set("test", "Abc");
+
+        $hasEntry = $cache->has("test");
+
+        $this->assertTrue($hasEntry);
+    }
+
+    public function testHasReturnsFalseForMissingKey(): void
+    {
+        $cache = new ArrayServiceCache();
+        $cache->set("test2", "Abc");
+
+        $hasEntry = $cache->has("test");
+
+        $this->assertFalse($hasEntry);
+    }
+
+    public function testCountChecksTheNumberOfEntries(): void
+    {
+        $cache = new ArrayServiceCache();
+        $cache->set("test1", "Abc");
+        $cache->set("test2", "Def");
+
+        $count = $cache->count();
+
+        $this->assertEquals(2, $count);
+    }
+
+    public function testGetAllRetrievesAllCacheEntries(): void
     {
         $cache = new ArrayServiceCache();
         $cache->set("test1", 123);
         $cache->set("test2", 456);
-        $this->assertEquals(['test1' => 123, 'test2' => 456], $cache->getAll());
+
+        $allEntries = $cache->getAll();
+
+        $this->assertEquals(['test1' => 123, 'test2' => 456], $allEntries);
     }
 }

--- a/tests/Cache/NoOpServiceCacheTest.php
+++ b/tests/Cache/NoOpServiceCacheTest.php
@@ -38,6 +38,7 @@ class NoOpServiceCacheTest extends TestCase
         $cache->remove("test");
         $this->assertFalse($cache->get("test"));
     }
+
     public function testRemove()
     {
         $cache = new NoOpServiceCache();

--- a/tests/Dummy/DummySimpleConstructor.php
+++ b/tests/Dummy/DummySimpleConstructor.php
@@ -1,14 +1,12 @@
 <?php
 namespace Tests\Dummy;
 
-use Bigcommerce\Injector\Cache\ServiceCacheInterface;
-
 class DummySimpleConstructor
 {
     /**
-     * @var ServiceCacheInterface
+     * @var DummyNoConstructor
      */
-    private $cache;
+    private $dummyNoConstructor;
 
     /**
      * @var DummyDependency
@@ -32,16 +30,15 @@ class DummySimpleConstructor
 
     /**
      * DummySimpleConstructor constructor.
-     * @param ServiceCacheInterface $cache
+     * @param DummyNoConstructor $dummyNoConstructor
      * @param DummyDependency $dummyDependency
      * @param string $name
      * @param int $age
      * @param string ...$args
      */
-    public function __construct(ServiceCacheInterface $cache, DummyDependency $dummyDependency, $name, $age = 25, string ...$args)
+    public function __construct(DummyNoConstructor $dummyNoConstructor, DummyDependency $dummyDependency, $name, $age = 25, string ...$args)
     {
-
-        $this->cache = $cache;
+        $this->dummyNoConstructor = $dummyNoConstructor;
         $this->dummyDependency = $dummyDependency;
         $this->name = $name;
         $this->age = $age;
@@ -51,11 +48,11 @@ class DummySimpleConstructor
     }
 
     /**
-     * @return ServiceCacheInterface
+     * @return DummyNoConstructor
      */
-    public function getCache()
+    public function getDummyNoConstructor()
     {
-        return $this->cache;
+        return $this->dummyNoConstructor;
     }
 
     /**

--- a/tests/InjectorTest.php
+++ b/tests/InjectorTest.php
@@ -1,11 +1,12 @@
 <?php
 namespace Tests;
 
-use Bigcommerce\Injector\Cache\ServiceCacheInterface;
 use Bigcommerce\Injector\Exception\InjectorInvocationException;
 use Bigcommerce\Injector\Injector;
+use Bigcommerce\Injector\Reflection\ClassInspector;
 use Bigcommerce\Injector\Reflection\ParameterInspector;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
@@ -32,7 +33,7 @@ class InjectorTest extends TestCase
     private $container;
 
     /**
-     * @var ParameterInspector|ObjectProphecy
+     * @var ClassInspector|ObjectProphecy
      */
     private $inspector;
 
@@ -40,7 +41,7 @@ class InjectorTest extends TestCase
     {
         parent::setUp();
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->inspector = $this->prophesize(ParameterInspector::class);
+        $this->inspector = $this->prophesize(ClassInspector::class);
     }
 
     /**
@@ -48,6 +49,7 @@ class InjectorTest extends TestCase
      */
     public function testCreateNoConstructor()
     {
+        $this->inspector->classHasMethod(DummyNoConstructor::class, "__construct")->willReturn(false);
         $injector = new Injector($this->container->reveal(), $this->inspector->reveal());
         $instance = $injector->create(DummyNoConstructor::class);
         $this->assertInstanceOf(DummyNoConstructor::class, $instance);
@@ -58,6 +60,8 @@ class InjectorTest extends TestCase
      */
     public function testCreatePrivateConstructor()
     {
+        $this->inspector->classHasMethod(DummyPrivateConstructor::class, "__construct")->willReturn(true);
+        $this->inspector->methodIsPublic(DummyPrivateConstructor::class, "__construct")->willReturn(false);
         $this->expectException(InjectorInvocationException::class);
         $this->expectExceptionMessageMatches(
             "/constructor isn't public/ims"
@@ -85,22 +89,23 @@ class InjectorTest extends TestCase
      */
     public function testCreateFromParameters()
     {
-        $cacheMock = $this->prophesize(ServiceCacheInterface::class)->reveal();
+        $dummyNoConstructor = $this->prophesize(DummyNoConstructor::class)->reveal();
         $dummyDependency = new DummyDependency(new DummySubDependency());
 
         $this->mockDummySimpleSignature();
 
         $injector = new Injector($this->container->reveal(), $this->inspector->reveal());
+        /** @var DummySimpleConstructor $instance */
         $instance = $injector->create(
             DummySimpleConstructor::class,
             [
-                "cache" => $cacheMock, //Parameter Name
+                "dummyNoConstructor" => $dummyNoConstructor, //Parameter Name
                 DummyDependency::class => $dummyDependency, //Parameter Type
                 2 => "bob" //Parameter Index
                 //Missing value - 'age' should use its default
             ]
         );
-        $this->assertSame($cacheMock, $instance->getCache());
+        $this->assertSame($dummyNoConstructor, $instance->getDummyNoConstructor());
         $this->assertSame($dummyDependency, $instance->getDummyDependency());
         $this->assertEquals("bob", $instance->getName());
         $this->assertEquals(25, $instance->getAge());
@@ -142,15 +147,16 @@ class InjectorTest extends TestCase
 
     public function testCreateBothNormalAndVariadicParameters()
     {
-        $cacheMock = $this->prophesize(ServiceCacheInterface::class)->reveal();
+        $dummyNoConstructor = $this->prophesize(DummyNoConstructor::class)->reveal();
         $dummyDependency = new DummyDependency(new DummySubDependency());
         $this->mockDummySimpleSignature();
 
         $injector = new Injector($this->container->reveal(), $this->inspector->reveal());
+        /** @var DummySimpleConstructor $instance */
         $instance = $injector->create(
             DummySimpleConstructor::class,
             [
-                "cache" => $cacheMock, //Parameter Name
+                "dummyNoConstructor" => $dummyNoConstructor, //Parameter Name
                 DummyDependency::class => $dummyDependency, //Parameter Type
                 2 => "bob", //Parameter Index
                 3 => 10, //Prameter Index
@@ -159,7 +165,7 @@ class InjectorTest extends TestCase
             ]
         );
 
-        $this->assertSame($cacheMock, $instance->getCache());
+        $this->assertSame($dummyNoConstructor, $instance->getDummyNoConstructor());
         $this->assertSame($dummyDependency, $instance->getDummyDependency());
         $this->assertEquals("bob", $instance->getName());
         $this->assertEquals(10, $instance->getAge());
@@ -191,27 +197,28 @@ class InjectorTest extends TestCase
      */
     public function testCreateFromContainer()
     {
-        $cacheMock = $this->prophesize(ServiceCacheInterface::class)->reveal();
+        $dummyNoConstructor = $this->prophesize(DummyNoConstructor::class)->reveal();
         $dummyDependency = new DummyDependency(new DummySubDependency());
 
         $this->mockDummySimpleSignature();
 
-        $this->container->has(ServiceCacheInterface::class)->willReturn(true);
-        $this->container->get(ServiceCacheInterface::class)->willReturn($cacheMock);
+        $this->container->has(DummyNoConstructor::class)->willReturn(true);
+        $this->container->get(DummyNoConstructor::class)->willReturn($dummyNoConstructor);
         $this->container->has(DummyDependency::class)->willReturn(true);
         $this->container->get(DummyDependency::class)->willReturn($dummyDependency);
 
         $injector = new Injector($this->container->reveal(), $this->inspector->reveal());
+        /** @var DummySimpleConstructor $instance */
         $instance = $injector->create(
             DummySimpleConstructor::class,
             [
-                //Missing value - 'cache' should come from container
+                //Missing value - 'dummyNoConstructor' should come from container
                 //Missing value - 'dummyDependency' should come from container
                 2 => "bob" //Parameter Index
                 //Missing value - 'age' should use its default
             ]
         );
-        $this->assertSame($cacheMock, $instance->getCache());
+        $this->assertSame($dummyNoConstructor, $instance->getDummyNoConstructor());
         $this->assertSame($dummyDependency, $instance->getDummyDependency());
         $this->assertEquals("bob", $instance->getName());
         $this->assertEquals(25, $instance->getAge());
@@ -224,7 +231,7 @@ class InjectorTest extends TestCase
      */
     public function testAutoCreate()
     {
-        $cacheMock = $this->prophesize(ServiceCacheInterface::class)->reveal();
+        $dummyNoConstructor = $this->prophesize(DummyNoConstructor::class)->reveal();
 
         $this->mockDummySimpleSignature();
         $this->mockDummyDependencySignature();
@@ -235,13 +242,13 @@ class InjectorTest extends TestCase
         $instance = $injector->create(
             DummySimpleConstructor::class,
             [
-                ServiceCacheInterface::class => $cacheMock,
+                DummyNoConstructor::class => $dummyNoConstructor,
                 //Missing value - 'dummyDependency' should come from auto-create
                 2 => "bob" //Parameter Index
                 //Missing value - 'age' should use its default
             ]
         );
-        $this->assertSame($cacheMock, $instance->getCache());
+        $this->assertSame($dummyNoConstructor, $instance->getDummyNoConstructor());
         $this->assertInstanceOf(DummyDependency::class, $instance->getDummyDependency());
         $this->assertEquals("bob", $instance->getName());
         $this->assertEquals(25, $instance->getAge());
@@ -260,7 +267,7 @@ class InjectorTest extends TestCase
             'Called when creating ' . addslashes(DummySimpleConstructor::class)
         ];
         $this->expectExceptionMessageMatches("/.*?" . implode(".*?", $messageContains) . ".*?/ims");
-        $cacheMock = $this->prophesize(ServiceCacheInterface::class)->reveal();
+        $dummyNoConstructor = $this->prophesize(DummyNoConstructor::class)->reveal();
 
         $this->mockDummySimpleSignature();
         $this->mockDummyDependencySignature();
@@ -270,7 +277,7 @@ class InjectorTest extends TestCase
         $instance = $injector->create(
             DummySimpleConstructor::class,
             [
-                ServiceCacheInterface::class => $cacheMock,
+                DummyNoConstructor::class => $dummyNoConstructor,
                 //Missing value - 'dummyDependency' should come from auto-create
                 2 => "bob" //Parameter Index
                 //Missing value - 'age' should use its default
@@ -282,7 +289,7 @@ class InjectorTest extends TestCase
     {
         $this->expectException(InjectorInvocationException::class);
         $this->expectExceptionMessageMatches(
-            '/missing parameter \'\$cache \[' . addslashes(ServiceCacheInterface::class) . '\]\'/ims'
+            '/missing parameter \'\$dummyNoConstructor \[' . addslashes(DummyNoConstructor::class) . '\]\'/ims'
         );
         $this->mockDummySimpleSignature();
 
@@ -361,7 +368,7 @@ class InjectorTest extends TestCase
             'Failed to invoke ' . addslashes(DummyNoConstructor::class) . '::setName - method doesn\'t exist.'
         ];
         $this->expectExceptionMessageMatches("/" . implode(".*?", $messageContains) . "/ims");
-        $this->inspector->getSignatureByClassName(DummyNoConstructor::class, "setName")->willThrow(
+        $this->inspector->getMethodSignature(DummyNoConstructor::class, "setName")->willThrow(
             new \ReflectionException("bad stuff")
         );
 
@@ -372,7 +379,11 @@ class InjectorTest extends TestCase
 
     private function mockDummyDependencySignature()
     {
-        $this->mockInspectorSignatureByReflectionClass(
+        $this->inspector->classHasMethod(DummyDependency::class,"__construct")
+            ->willReturn(true);
+        $this->inspector->methodIsPublic(DummyDependency::class,"__construct")
+            ->willReturn(true);
+        $this->mockInspectorSignatureByClassName(
             DummyDependency::class,
             "__construct",
             [
@@ -384,7 +395,11 @@ class InjectorTest extends TestCase
 
     private function mockDummySubDependencySignature()
     {
-        $this->mockInspectorSignatureByReflectionClass(
+        $this->inspector->classHasMethod(DummySubDependency::class,"__construct")
+            ->willReturn(true);
+        $this->inspector->methodIsPublic(DummySubDependency::class,"__construct")
+            ->willReturn(true);
+        $this->mockInspectorSignatureByClassName(
             DummySubDependency::class,
             "__construct",
             [
@@ -395,11 +410,15 @@ class InjectorTest extends TestCase
 
     private function mockDummySimpleSignature()
     {
-        $this->mockInspectorSignatureByReflectionClass(
+        $this->inspector->classHasMethod(DummySimpleConstructor::class,"__construct")
+            ->willReturn(true);
+        $this->inspector->methodIsPublic(DummySimpleConstructor::class,"__construct")
+            ->willReturn(true);
+        $this->mockInspectorSignatureByClassName(
             DummySimpleConstructor::class,
             "__construct",
             [
-                ["name" => "cache", "type" => ServiceCacheInterface::class],
+                ["name" => "dummyNoConstructor", "type" => DummyNoConstructor::class],
                 ["name" => "dummyDependency", "type" => DummyDependency::class],
                 ["name" => "name"],
                 ["name" => "age", "default" => 25],
@@ -410,7 +429,11 @@ class InjectorTest extends TestCase
 
     private function mockDummyVariadicSignature()
     {
-        $this->mockInspectorSignatureByReflectionClass(
+        $this->inspector->classHasMethod(DummyVariadicConstructor::class,"__construct")
+            ->willReturn(true);
+        $this->inspector->methodIsPublic(DummyVariadicConstructor::class,"__construct")
+            ->willReturn(true);
+        $this->mockInspectorSignatureByClassName(
             DummyVariadicConstructor::class,
             "__construct",
             [
@@ -419,17 +442,9 @@ class InjectorTest extends TestCase
         );
     }
 
-    private function mockInspectorSignatureByReflectionClass($className, $methodName, $returns)
-    {
-        $this->inspector->getSignatureByReflectionClass(
-            new \ReflectionClass($className),
-            $methodName
-        )->willReturn($returns);
-    }
-
     private function mockInspectorSignatureByClassName($className, $methodName, $returns)
     {
-        $this->inspector->getSignatureByClassName(
+        $this->inspector->getMethodSignature(
             $className,
             $methodName
         )->willReturn($returns);

--- a/tests/Reflection/CachingClassInspectorTest.php
+++ b/tests/Reflection/CachingClassInspectorTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reflection;
+
+use Bigcommerce\Injector\Cache\ArrayServiceCache;
+use Bigcommerce\Injector\Reflection\CachingClassInspector;
+use Bigcommerce\Injector\Reflection\ClassInspector;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionException;
+use Tests\Dummy\DummyDependency;
+
+class CachingClassInspectorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private CachingClassInspector $subject;
+    private ArrayServiceCache|ObjectProphecy $serviceCache;
+    private ClassInspector|ObjectProphecy $classInspector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serviceCache = $this->prophesize(ArrayServiceCache::class);
+        $this->classInspector = $this->prophesize(ClassInspector::class);
+        $this->subject = new CachingClassInspector(
+            $this->classInspector->reveal(),
+            $this->serviceCache->reveal(),
+        );
+    }
+
+    public function testWarmCachePopulatesCaches(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->classHasMethod(DummyDependency::class, 'isEnabled')->willReturn(true);
+        $this->classInspector->methodIsPublic(DummyDependency::class, 'isEnabled')->willReturn(true);
+        $this->classInspector->getMethodSignature(DummyDependency::class, 'isEnabled')->willReturn([]);
+
+        $this->subject->warmCache(DummyDependency::class, 'isEnabled');
+
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true)
+            ->shouldHaveBeenCalled();
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true)
+            ->shouldHaveBeenCalled();
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", [])
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testClassHasMethodUsesCachedResult(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(true);
+        $this->serviceCache->get(Argument::cetera())->willReturn(true);
+
+        $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+
+        $this->classInspector->classHasMethod(Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
+    public function testClassHasMethodReturnsTrueForExistingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->classHasMethod(DummyDependency::class, 'isEnabled')->willReturn(true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true);
+
+        $hasMethod = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+
+        $this->assertTrue($hasMethod);
+    }
+
+    public function testClassHasMethodReturnsFalseForMissingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->classHasMethod(DummyDependency::class, 'isEnabled2')->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2::exists", false);
+
+        $hasMethod = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled2');
+
+        $this->assertFalse($hasMethod);
+    }
+
+    public function testClassHasMethodAddsResultToCacheOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true);
+        $this->classInspector->classHasMethod(DummyDependency::class, 'isEnabled')->willReturn(true);
+
+        $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true)
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testMethodIsPublicUsesCachedResult(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(true);
+        $this->serviceCache->get(Argument::cetera())->willReturn(true);
+
+        $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+
+        $this->classInspector->methodIsPublic(Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
+    public function testMethodIsPublicReturnsTrueForExistingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->methodIsPublic(DummyDependency::class, 'isEnabled')->willReturn(true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true);
+
+        $hasMethod = $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+
+        $this->assertTrue($hasMethod);
+    }
+
+    public function testMethodIsPublicThrowsExceptionForMissingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2::is_public", false);
+        $this->classInspector->methodIsPublic(DummyDependency::class, 'isEnabled2')->willThrow(ReflectionException::class);
+
+        $this->expectException(ReflectionException::class);
+        $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled2');
+    }
+
+    public function testMethodIsPublicAddsResultToCacheOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true);
+        $this->classInspector->methodIsPublic(DummyDependency::class, 'isEnabled')->willReturn(true);
+
+        $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true)
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testGetMethodSignatureUsesCachedResult(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(true);
+        $this->serviceCache->get(Argument::cetera())->willReturn([]);
+
+        $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
+
+        $this->classInspector->getMethodSignature(Argument::cetera())->shouldNotHaveBeenCalled();
+    }
+
+
+    public function testGetMethodSignatureReturnsSignatureForExistingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", []);
+        $this->classInspector->getMethodSignature(Argument::any(), 'isEnabled')->willReturn([]);
+
+        $signature = $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
+
+        $this->assertEquals([], $signature);
+    }
+
+    public function testGetMethodSignatureThrowsExceptionForMissingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->classInspector->getMethodSignature(Argument::any(), 'isEnabled2')->willThrow(ReflectionException::class);
+
+        $this->expectException(ReflectionException::class);
+        $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled2');
+    }
+
+    public function testGetMethodSignatureAddsResultToCacheOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", []);
+        $this->classInspector->getMethodSignature(Argument::any(), 'isEnabled')->willReturn([]);
+
+        $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
+
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", [])
+            ->shouldHaveBeenCalled();
+    }
+}

--- a/tests/Reflection/ClassInspectorTest.php
+++ b/tests/Reflection/ClassInspectorTest.php
@@ -46,20 +46,20 @@ class ClassInspectorTest extends TestCase
     public function testInspectMethodPopulatesCaches(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", []);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::cetera());
         $this->parameterInspector->getSignatureByReflectionClass(Argument::type(ReflectionClass::class), 'isEnabled')->willReturn([]);
 
         $this->subject->inspectMethod(DummyDependency::class, 'isEnabled');
 
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true)
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true)
             ->shouldHaveBeenCalled();
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true)
             ->shouldHaveBeenCalled();
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", [])
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", [])
             ->shouldHaveBeenCalled();
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class))
             ->shouldHaveBeenCalled();
@@ -78,7 +78,7 @@ class ClassInspectorTest extends TestCase
     public function testClassHasMethodReturnsTrueForExistingMethodOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
@@ -90,7 +90,7 @@ class ClassInspectorTest extends TestCase
     public function testClassHasMethodReturnsFalseForMissingMethodOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2_exists", false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2::exists", false);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
@@ -102,13 +102,13 @@ class ClassInspectorTest extends TestCase
     public function testClassHasMethodAddsResultToCacheOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
 
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true)
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::exists", true)
             ->shouldHaveBeenCalled();
     }
 
@@ -184,7 +184,7 @@ class ClassInspectorTest extends TestCase
     public function testGetMethodSignatureReturnsSignatureForExistingMethodOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", []);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
         $this->parameterInspector->getSignatureByReflectionClass(Argument::any(), 'isEnabled')->willReturn([]);
@@ -208,14 +208,14 @@ class ClassInspectorTest extends TestCase
     public function testGetMethodSignatureAddsResultToCacheOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", []);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
         $this->parameterInspector->getSignatureByReflectionClass(Argument::any(), 'isEnabled')->willReturn([]);
 
         $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
 
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", [])
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::signature", [])
             ->shouldHaveBeenCalled();
     }
 }

--- a/tests/Reflection/ClassInspectorTest.php
+++ b/tests/Reflection/ClassInspectorTest.php
@@ -47,7 +47,7 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::cetera());
@@ -57,7 +57,7 @@ class ClassInspectorTest extends TestCase
 
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true)
             ->shouldHaveBeenCalled();
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true)
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true)
             ->shouldHaveBeenCalled();
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", [])
             ->shouldHaveBeenCalled();
@@ -125,7 +125,7 @@ class ClassInspectorTest extends TestCase
     public function testMethodIsPublicReturnsTrueForExistingMethodOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
@@ -137,7 +137,7 @@ class ClassInspectorTest extends TestCase
     public function testMethodIsPublicThrowsExceptionForMissingMethodOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2_is_public", false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2::is_public", false);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
@@ -148,7 +148,7 @@ class ClassInspectorTest extends TestCase
     public function testMethodIsPublicReturnsFalseForPrivateMethodOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyPrivateConstructor::__construct_is_public", false);
+        $this->serviceCache->set("Tests\Dummy\DummyPrivateConstructor::__construct::is_public", false);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
@@ -160,13 +160,13 @@ class ClassInspectorTest extends TestCase
     public function testMethodIsPublicAddsResultToCacheOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true);
         $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
         $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
 
-        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true)
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled::is_public", true)
             ->shouldHaveBeenCalled();
     }
 

--- a/tests/Reflection/ClassInspectorTest.php
+++ b/tests/Reflection/ClassInspectorTest.php
@@ -8,7 +8,7 @@ use Bigcommerce\Injector\Cache\ArrayServiceCache;
 use Bigcommerce\Injector\Reflection\ClassInspector;
 use Bigcommerce\Injector\Reflection\ClassInspectorStats;
 use Bigcommerce\Injector\Reflection\ParameterInspector;
-use Bigcommerce\Injector\Reflection\ReflectionClassMap;
+use Bigcommerce\Injector\Reflection\ReflectionClassCache;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -24,7 +24,7 @@ class ClassInspectorTest extends TestCase
 
     private ClassInspector $subject;
     private ArrayServiceCache|ObjectProphecy $serviceCache;
-    private ReflectionClassMap|ObjectProphecy $reflectionClassMap;
+    private ReflectionClassCache|ObjectProphecy $reflectionClassCache;
     private ParameterInspector|ObjectProphecy $parameterInspector;
     private ClassInspectorStats|ObjectProphecy $classInspectorStats;
 
@@ -32,11 +32,11 @@ class ClassInspectorTest extends TestCase
     {
         parent::setUp();
         $this->serviceCache = $this->prophesize(ArrayServiceCache::class);
-        $this->reflectionClassMap = $this->prophesize(ReflectionClassMap::class);
+        $this->reflectionClassCache = $this->prophesize(ReflectionClassCache::class);
         $this->parameterInspector = $this->prophesize(ParameterInspector::class);
         $this->classInspectorStats = $this->prophesize(ClassInspectorStats::class);
         $this->subject = new ClassInspector(
-            $this->reflectionClassMap->reveal(),
+            $this->reflectionClassCache->reveal(),
             $this->parameterInspector->reveal(),
             $this->serviceCache->reveal(),
             $this->classInspectorStats->reveal(),
@@ -49,8 +49,8 @@ class ClassInspectorTest extends TestCase
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::cetera());
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::cetera());
         $this->parameterInspector->getSignatureByReflectionClass(Argument::type(ReflectionClass::class), 'isEnabled')->willReturn([]);
 
         $this->subject->inspectMethod(DummyDependency::class, 'isEnabled');
@@ -61,7 +61,7 @@ class ClassInspectorTest extends TestCase
             ->shouldHaveBeenCalled();
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", [])
             ->shouldHaveBeenCalled();
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class))
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class))
             ->shouldHaveBeenCalled();
     }
 
@@ -79,8 +79,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $hasMethod = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
 
@@ -91,8 +91,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2_exists", false);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $hasMethod = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled2');
 
@@ -103,8 +103,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
 
@@ -126,8 +126,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $hasMethod = $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
 
@@ -138,8 +138,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2_is_public", false);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $this->expectException(ReflectionException::class);
         $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled2');
@@ -149,8 +149,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyPrivateConstructor::__construct_is_public", false);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $isPublic = $this->subject->methodIsPublic(DummyPrivateConstructor::class, '__construct');
 
@@ -161,8 +161,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
 
         $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
 
@@ -185,8 +185,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
         $this->parameterInspector->getSignatureByReflectionClass(Argument::any(), 'isEnabled')->willReturn([]);
 
         $signature = $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
@@ -197,8 +197,8 @@ class ClassInspectorTest extends TestCase
     public function testGetMethodSignatureThrowsExceptionForMissingMethodOnCacheMiss(): void
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
         $this->parameterInspector->getSignatureByReflectionClass(Argument::any(), 'isEnabled2')->willThrow(new ReflectionException());
 
         $this->expectException(ReflectionException::class);
@@ -209,8 +209,8 @@ class ClassInspectorTest extends TestCase
     {
         $this->serviceCache->has(Argument::cetera())->willReturn(false);
         $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
-        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
-        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->reflectionClassCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassCache->put(Argument::type(ReflectionClass::class));
         $this->parameterInspector->getSignatureByReflectionClass(Argument::any(), 'isEnabled')->willReturn([]);
 
         $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');

--- a/tests/Reflection/ClassInspectorTest.php
+++ b/tests/Reflection/ClassInspectorTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Reflection;
+
+use Bigcommerce\Injector\Cache\ArrayServiceCache;
+use Bigcommerce\Injector\Reflection\ClassInspector;
+use Bigcommerce\Injector\Reflection\ClassInspectorStats;
+use Bigcommerce\Injector\Reflection\ParameterInspector;
+use Bigcommerce\Injector\Reflection\ReflectionClassMap;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionException;
+use Tests\Dummy\DummyDependency;
+use ReflectionClass;
+use Tests\Dummy\DummyPrivateConstructor;
+
+class ClassInspectorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ClassInspector $subject;
+    private ArrayServiceCache|ObjectProphecy $serviceCache;
+    private ReflectionClassMap|ObjectProphecy $reflectionClassMap;
+    private ParameterInspector|ObjectProphecy $parameterInspector;
+    private ClassInspectorStats|ObjectProphecy $classInspectorStats;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serviceCache = $this->prophesize(ArrayServiceCache::class);
+        $this->reflectionClassMap = $this->prophesize(ReflectionClassMap::class);
+        $this->parameterInspector = $this->prophesize(ParameterInspector::class);
+        $this->classInspectorStats = $this->prophesize(ClassInspectorStats::class);
+        $this->subject = new ClassInspector(
+            $this->reflectionClassMap->reveal(),
+            $this->parameterInspector->reveal(),
+            $this->serviceCache->reveal(),
+            $this->classInspectorStats->reveal(),
+        );
+    }
+
+    public function testInspectMethodPopulatesCaches(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::cetera());
+        $this->parameterInspector->getSignatureByReflectionClass(Argument::type(ReflectionClass::class), 'isEnabled')->willReturn([]);
+
+        $this->subject->inspectMethod(DummyDependency::class, 'isEnabled');
+
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true)
+            ->shouldHaveBeenCalled();
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true)
+            ->shouldHaveBeenCalled();
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", [])
+            ->shouldHaveBeenCalled();
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class))
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testClassHasMethodUsesCachedResult(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(true);
+        $this->serviceCache->get(Argument::cetera())->willReturn(true);
+
+        $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+
+        $this->classInspectorStats->incrementReflectionClassesCreated()->shouldNotHaveBeenCalled();
+    }
+
+    public function testClassHasMethodReturnsTrueForExistingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+
+        $hasMethod = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+
+        $this->assertTrue($hasMethod);
+    }
+
+    public function testClassHasMethodReturnsFalseForMissingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2_exists", false);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+
+        $hasMethod = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled2');
+
+        $this->assertFalse($hasMethod);
+    }
+
+    public function testClassHasMethodAddsResultToCacheOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+
+        $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_exists", true)
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testMethodIsPublicUsesCachedResult(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(true);
+        $this->serviceCache->get(Argument::cetera())->willReturn(true);
+
+        $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+
+        $this->classInspectorStats->incrementReflectionClassesCreated()->shouldNotHaveBeenCalled();
+    }
+
+    public function testMethodIsPublicReturnsTrueForExistingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+
+        $hasMethod = $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+
+        $this->assertTrue($hasMethod);
+    }
+
+    public function testMethodIsPublicThrowsExceptionForMissingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled2_is_public", false);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+
+        $this->expectException(ReflectionException::class);
+        $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled2');
+    }
+
+    public function testMethodIsPublicReturnsFalseForPrivateMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyPrivateConstructor::__construct_is_public", false);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+
+        $isPublic = $this->subject->methodIsPublic(DummyPrivateConstructor::class, '__construct');
+
+        $this->assertFalse($isPublic);
+    }
+
+    public function testMethodIsPublicAddsResultToCacheOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+
+        $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_is_public", true)
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testGetMethodSignatureUsesCachedResult(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(true);
+        $this->serviceCache->get(Argument::cetera())->willReturn([]);
+
+        $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
+
+        $this->classInspectorStats->incrementReflectionClassesCreated()->shouldNotHaveBeenCalled();
+    }
+
+
+    public function testGetMethodSignatureReturnsSignatureForExistingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->parameterInspector->getSignatureByReflectionClass(Argument::any(), 'isEnabled')->willReturn([]);
+
+        $signature = $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
+
+        $this->assertEquals([], $signature);
+    }
+
+    public function testGetMethodSignatureThrowsExceptionForMissingMethodOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->parameterInspector->getSignatureByReflectionClass(Argument::any(), 'isEnabled2')->willThrow(new ReflectionException());
+
+        $this->expectException(ReflectionException::class);
+        $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled2');
+    }
+
+    public function testGetMethodSignatureAddsResultToCacheOnCacheMiss(): void
+    {
+        $this->serviceCache->has(Argument::cetera())->willReturn(false);
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", []);
+        $this->reflectionClassMap->has(Argument::cetera())->willReturn(false);
+        $this->reflectionClassMap->put(Argument::type(ReflectionClass::class));
+        $this->parameterInspector->getSignatureByReflectionClass(Argument::any(), 'isEnabled')->willReturn([]);
+
+        $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
+
+        $this->serviceCache->set("Tests\Dummy\DummyDependency::isEnabled_signature", [])
+            ->shouldHaveBeenCalled();
+    }
+}

--- a/tests/Reflection/ParameterInspectorTest.php
+++ b/tests/Reflection/ParameterInspectorTest.php
@@ -1,12 +1,10 @@
 <?php
 namespace Tests\Reflection;
 
-use Bigcommerce\Injector\Cache\ArrayServiceCache;
-use Bigcommerce\Injector\Cache\ServiceCacheInterface;
 use Bigcommerce\Injector\Reflection\ParameterInspector;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use Tests\Dummy\DummyNoConstructor;
 use Tests\Dummy\MagicCallDummy;
 
 /**
@@ -17,13 +15,9 @@ class ParameterInspectorTest extends TestCase
 {
     use ProphecyTrait;
 
-    /** @var ObjectProphecy|ServiceCacheInterface */
-    private $cache;
-
     public function setUp(): void
     {
         parent::setUp();
-        $this->cache = $this->prophesize(ArrayServiceCache::class);
     }
 
     /**
@@ -31,27 +25,27 @@ class ParameterInspectorTest extends TestCase
      */
     public function test()
     {
-        $ref = new ParameterInspector($this->cache->reveal());
+        $ref = new ParameterInspector();
         $signature = $ref->getSignatureByReflectionClass(new \ReflectionClass($this), "example1");
         $this->assertEquals(
-            ["name" => "cache", "type" => ArrayServiceCache::class],
+            ["name" => "dummyNoConstructor", "type" => DummyNoConstructor::class],
             $signature[0]
         );
     }
 
     public function testGetSignatureTypes()
     {
-        $ref = new ParameterInspector($this->cache->reveal());
+        $ref = new ParameterInspector();
         $signature = $ref->getSignatureByClassName(self::class, "example1");
         $this->assertEquals(
-            ["name" => "cache", "type" => ArrayServiceCache::class],
+            ["name" => "dummyNoConstructor", "type" => DummyNoConstructor::class],
             $signature[0]
         );
     }
 
     public function testGetSignatureDefaults()
     {
-        $ref = new ParameterInspector($this->cache->reveal());
+        $ref = new ParameterInspector();
         $signature = $ref->getSignatureByClassName(self::class, "example1");
         $this->assertCount(2, $signature);
         $this->assertEquals(
@@ -62,7 +56,7 @@ class ParameterInspectorTest extends TestCase
 
     public function testGetSignatureNoDefaults()
     {
-        $ref = new ParameterInspector($this->cache->reveal());
+        $ref = new ParameterInspector();
         $signature = $ref->getSignatureByClassName(self::class, "example2");
         $this->assertCount(2, $signature);
         $this->assertEquals(
@@ -77,27 +71,27 @@ class ParameterInspectorTest extends TestCase
     public function testGetSignatureInvalidMethod()
     {
         $this->expectException(\ReflectionException::class);
-        $ref = new ParameterInspector($this->cache->reveal());
+        $ref = new ParameterInspector();
         $ref->getSignatureByClassName(self::class, "invalidMethod");
     }
 
     public function testGetSignatureMagicCallMethod()
     {
-        $ref = new ParameterInspector($this->cache->reveal());
+        $ref = new ParameterInspector();
         $signature = $ref->getSignatureByClassName(MagicCallDummy::class, "strangeMethodName");
         $this->assertEquals([], $signature);
     }
 
     public function testGetSignatureNoParameters()
     {
-        $ref = new ParameterInspector($this->cache->reveal());
+        $ref = new ParameterInspector();
         $signature = $ref->getSignatureByClassName(self::class, "example3");
         $this->assertEquals([], $signature);
     }
 
     public function testGetSignatureVariadicParameter()
     {
-        $ref = new ParameterInspector($this->cache->reveal());
+        $ref = new ParameterInspector();
         $signature = $ref->getSignatureByClassName(self::class, "example4");
         $this->assertEquals(
             ["name" => "args", "variadic" => true],
@@ -105,24 +99,12 @@ class ParameterInspectorTest extends TestCase
         );
     }
 
-    public function testCacheHit()
-    {
-        $cacheSignature = [
-            ["name" => "secretParameter", "type" => null, "default" => 1]
-        ];
-        $this->cache->get(self::class . "::secretMethod")->willReturn($cacheSignature);
-        $ref = new ParameterInspector($this->cache->reveal());
-
-        $signature = $ref->getSignatureByClassName(self::class, "secretMethod");
-        $this->assertEquals($cacheSignature, $signature);
-    }
-
     /**
      * THIS METHOD IS INSPECTED AS PART OF THIS TEST. DO NOT REMOVE
-     * @param ArrayServiceCache $cache
+     * @param DummyNoConstructor $dummyNoConstructor
      * @param int $default
      */
-    private function example1(ArrayServiceCache $cache, $default = 1)
+    private function example1(DummyNoConstructor $dummyNoConstructor, $default = 1)
     {
     }
 

--- a/tests/Reflection/ReflectionClassCacheTest.php
+++ b/tests/Reflection/ReflectionClassCacheTest.php
@@ -16,11 +16,6 @@ class ReflectionClassCacheTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testHasReturnsTrueWhenEntryExistsForGivenReflectionClass(): void
     {
         $subject = new ReflectionClassCache(10);

--- a/tests/Reflection/ReflectionClassCacheTest.php
+++ b/tests/Reflection/ReflectionClassCacheTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Reflection;
+
+use Bigcommerce\Injector\Reflection\ReflectionClassCache;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use ReflectionClass;
+use Tests\Dummy\DummyDependency;
+use Tests\Dummy\DummyNoConstructor;
+use Tests\Dummy\DummySimpleConstructor;
+
+class ReflectionClassCacheTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testHasReturnsTrueWhenEntryExistsForGivenReflectionClass(): void
+    {
+        $subject = new ReflectionClassCache(10);
+        $subject->put(new ReflectionClass(DummyDependency::class));
+
+        $result = $subject->has(DummyDependency::class);
+
+        $this->assertTrue($result);
+    }
+
+    public function testCountReturnsTotalNumberOfCacheEntries(): void
+    {
+        $subject = new ReflectionClassCache(10);
+        $subject->put(new ReflectionClass(DummyDependency::class));
+        $subject->put(new ReflectionClass(DummyNoConstructor::class));
+
+        $result = $subject->count();
+
+        $this->assertEquals(2, $result);
+    }
+
+    public function testGetReturnsReflectionClassForGivenClassIfPresent(): void
+    {
+        $subject = new ReflectionClassCache(10);
+        $subject->put(new ReflectionClass(DummyDependency::class));
+
+        $result = $subject->get(DummyDependency::class);
+
+        $this->assertEquals(DummyDependency::class, $result->getName());
+    }
+
+    public function testPutAddsItemToCache(): void
+    {
+        $subject = new ReflectionClassCache(10);
+        $subject->put(new ReflectionClass(DummyDependency::class));
+
+        $result = $subject->count();
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function testCacheDoesNotExceedMaxSize(): void
+    {
+        $subject = new ReflectionClassCache(2);
+        $subject->put(new ReflectionClass(DummyDependency::class));
+        $subject->put(new ReflectionClass(DummyNoConstructor::class));
+        $subject->put(new ReflectionClass(DummySimpleConstructor::class));
+
+        $result = $subject->count();
+
+        $this->assertEquals(2, $result);
+    }
+}


### PR DESCRIPTION
#### What?

Currently only the signature information obtained by reflection is cacheable. This PR expands caching to support all reflection results. When a class has been inspected, no further reflection is required.

Bonus: Update min version to PHP 8.1

#### Tickets / Documentation

Add links to any relevant issues and documentation.

- [PHPMNT-100](https://bigcommercecloud.atlassian.net/browse/PHPMNT-100)
- https://github.com/bigcommerce/bigcommerce/pull/58084



[PHPMNT-100]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ