### PR TITLE
PHPMNT-100 Allow for custom service cache via InjectorFactory

### DIFF
--- a/src/InjectorFactory.php
+++ b/src/InjectorFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bigcommerce\Injector;
 
 use Bigcommerce\Injector\Cache\ArrayServiceCache;
+use Bigcommerce\Injector\Cache\ServiceCacheInterface;
 use Bigcommerce\Injector\Reflection\CachingClassInspector;
 use Bigcommerce\Injector\Reflection\ClassInspector;
 use Bigcommerce\Injector\Reflection\ClassInspectorStats;
@@ -14,8 +15,11 @@ use Psr\Container\ContainerInterface;
 
 class InjectorFactory
 {
-    public static function create(ContainerInterface $container, int $reflectionClassCacheSize = 50): InjectorInterface
-    {
+    public static function create(
+        ContainerInterface $container,
+        int $reflectionClassCacheSize = 50,
+        ServiceCacheInterface $serviceCache = null,
+    ): InjectorInterface {
         $classInspector = new ClassInspector(
             new ReflectionClassCache($reflectionClassCacheSize),
             new ParameterInspector(),
@@ -24,7 +28,7 @@ class InjectorFactory
 
         $cachingClassInspector = new CachingClassInspector(
             $classInspector,
-            new ArrayServiceCache(),
+            $serviceCache ?? new ArrayServiceCache(),
         );
 
         return new Injector($container, $cachingClassInspector);

--- a/tests/InjectorFactoryTest.php
+++ b/tests/InjectorFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Bigcommerce\Injector\Cache\ArrayServiceCache;
+use Bigcommerce\Injector\Injector;
+use Bigcommerce\Injector\InjectorFactory;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+
+class InjectorFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ContainerInterface|ObjectProphecy
+     */
+    private $container;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->container = $this->prophesize(ContainerInterface::class);
+    }
+
+    public function testFactoryCanCreateAnInjector(): void
+    {
+        $injector = InjectorFactory::create($this->container->reveal());
+
+        $this->assertInstanceOf(Injector::class, $injector);
+    }
+
+    public function testFactoryCanCreateAnInjectorWithASpecificReflectionCacheSize(): void
+    {
+        $injector = InjectorFactory::create($this->container->reveal(), 20);
+
+        $this->assertInstanceOf(Injector::class, $injector);
+    }
+
+    public function testFactoryCanCreateAnInjectorWithASpecificServiceCache(): void
+    {
+        $injector = InjectorFactory::create($this->container->reveal(), serviceCache: new ArrayServiceCache());
+
+        $this->assertInstanceOf(Injector::class, $injector);
+    }
+}


### PR DESCRIPTION
#### What?

 Allow for the service cache  object to be specified via InjectorFactory::create. This will support the mock-injector which uses a StaticArrayServiceCache instead of the default.

#### Tickets / Documentation

Add links to any relevant issues and documentation.

https://github.com/bigcommerce/mock-injector/pull/29
