### PR TITLE
PHPMNT-100 Ensure CachingClassInspector works with no-op cache

### DIFF
--- a/src/Reflection/CachingClassInspector.php
+++ b/src/Reflection/CachingClassInspector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Bigcommerce\Injector\Reflection;
 
 use Bigcommerce\Injector\Cache\ServiceCacheInterface;
-use ReflectionClass;
 use ReflectionException;
 
 class CachingClassInspector implements ClassInspectorInterface
@@ -44,14 +43,14 @@ class CachingClassInspector implements ClassInspectorInterface
     public function classHasMethod(string $class, string $method): bool
     {
         $key = "$class::{$method}::exists";
-        if (!$this->serviceCache->has($key)) {
-            $this->serviceCache->set(
-                $key,
-                $this->classInspector->classHasMethod($class, $method),
-            );
+        if ($this->serviceCache->has($key)) {
+            $value = $this->serviceCache->get($key);
+        } else {
+            $value = $this->classInspector->classHasMethod($class, $method);
+            $this->serviceCache->set($key, $value);
         }
 
-        return $this->serviceCache->get($key);
+        return $value;
     }
 
     /**
@@ -65,14 +64,14 @@ class CachingClassInspector implements ClassInspectorInterface
     public function methodIsPublic(string $class, string $method): bool
     {
         $key = "$class::{$method}::is_public";
-        if (!$this->serviceCache->has($key)) {
-            $this->serviceCache->set(
-                $key,
-                $this->classInspector->methodIsPublic($class, $method),
-            );
+        if ($this->serviceCache->has($key)) {
+            $value = $this->serviceCache->get($key);
+        } else {
+            $value = $this->classInspector->methodIsPublic($class, $method);
+            $this->serviceCache->set($key, $value);
         }
 
-        return $this->serviceCache->get($key);
+        return $value;
     }
 
     /**
@@ -86,14 +85,14 @@ class CachingClassInspector implements ClassInspectorInterface
     public function getMethodSignature(string $class, string $method): array
     {
         $key = "$class::{$method}::signature";
-        if (!$this->serviceCache->has($key)) {
-            $this->serviceCache->set(
-                $key,
-                $this->classInspector->getMethodSignature($class, $method),
-            );
+        if ($this->serviceCache->has($key)) {
+            $value = $this->serviceCache->get($key);
+        } else {
+            $value = $this->classInspector->getMethodSignature($class, $method);
+            $this->serviceCache->set($key, $value);
         }
 
-        return $this->serviceCache->get($key);
+        return $value;
     }
 
     public function getStats(): ClassInspectorStats

--- a/tests/Reflection/NoOpCachingClassInspectorTest.php
+++ b/tests/Reflection/NoOpCachingClassInspectorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Reflection;
+
+use Bigcommerce\Injector\Cache\ArrayServiceCache;
+use Bigcommerce\Injector\Cache\ServiceCacheInterface;
+use Bigcommerce\Injector\Reflection\CachingClassInspector;
+use Bigcommerce\Injector\Reflection\ClassInspector;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Tests\Dummy\DummyDependency;
+
+class NoOpCachingClassInspectorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private CachingClassInspector $subject;
+    private ArrayServiceCache|ObjectProphecy $serviceCache;
+    private ClassInspector|ObjectProphecy $classInspector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $serviceCache = $this->prophesize(ServiceCacheInterface::class);
+        $serviceCache->has(Argument::cetera())->willReturn(false);
+        $serviceCache->get(Argument::cetera())->willReturn(false);
+
+        $this->serviceCache = $serviceCache;
+        $this->classInspector = $this->prophesize(ClassInspector::class);
+        $this->subject = new CachingClassInspector(
+            $this->classInspector->reveal(),
+            $this->serviceCache->reveal(),
+        );
+    }
+
+    public function testClassHasMethodWorksWithNoOpCache(): void
+    {
+        $this->classInspector->classHasMethod(Argument::cetera())->willReturn(true);
+        $this->serviceCache->set(Argument::cetera())->shouldBeCalled();
+
+        $hasMethod = $this->subject->classHasMethod(DummyDependency::class, 'isEnabled');
+
+        $this->assertTrue($hasMethod);
+    }
+
+    public function testMethodIsPublicWorksWithNoOpCache(): void
+    {
+        $this->classInspector->methodIsPublic(Argument::cetera())->willReturn(true);
+        $this->serviceCache->set(Argument::cetera())->shouldBeCalled();
+
+        $public = $this->subject->methodIsPublic(DummyDependency::class, 'isEnabled');
+
+        $this->assertTrue($public);
+    }
+
+    public function testGetMethodSignatureWorksWithNoOpCache(): void
+    {
+        $this->classInspector->getMethodSignature(Argument::cetera())->willReturn([]);
+        $this->serviceCache->set(Argument::cetera())->shouldBeCalled();
+
+        $signature = $this->subject->getMethodSignature(DummyDependency::class, 'isEnabled');
+
+        $this->assertEquals([], $signature);
+    }
+}


### PR DESCRIPTION
#### What?

I noticed the implementation of CachingClassInspector doesn't work with a no-op cache because it reads from the cache after setting it. This updates it so it doesn't depend on reading the set value.

#### Tickets / Documentation

Add links to any relevant issues and documentation.

- [PHPMNT-100](https://bigcommercecloud.atlassian.net/browse/PHPMNT-100)



[PHPMNT-100]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ