### PR TITLE
Improve performance of ReflectionClassCache::evict()

### DIFF
--- a/src/Reflection/ReflectionClassCache.php
+++ b/src/Reflection/ReflectionClassCache.php
@@ -57,6 +57,10 @@ class ReflectionClassCache implements Countable
 
     private function evictOneObject(): void
     {
-        array_shift($this->map);
+        // Get the least recently used item (first in insertion order)
+        $lruClassName = array_key_first($this->map);
+        if ($lruClassName !== null) {
+            unset($this->map[$lruClassName]);
+        }
     }
 }


### PR DESCRIPTION
## What/Why?
Changes eviction from O(n) (array_shift()) to O(1) (array_key_first() and unset()). That fixes an issue where performance degrades as the cache grows

## Rollout/Rollback
Merge / revert

## Testing
Tests still pass