### PR TITLE
Reduce number of getType() calls in Bigcommerce\Injector\Reflection\ParameterInspector::getMethodSignature()

### DIFF
--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -133,12 +133,6 @@ parameters:
 			path: ../src/Reflection/ParameterInspector.php
 
 		-
-			message: '#^Call to an undefined method ReflectionType\:\:isBuiltin\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: ../src/Reflection/ParameterInspector.php
-
-		-
 			message: '#^Method Bigcommerce\\Injector\\Reflection\\ParameterInspector\:\:getMethodSignature\(\) has parameter \$refClass with generic class ReflectionClass but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1

--- a/src/Reflection/ParameterInspector.php
+++ b/src/Reflection/ParameterInspector.php
@@ -63,8 +63,9 @@ class ParameterInspector
                 $parameterSignature = [
                     "name" => $name
                 ];
-                if ($parameter->getType() && !$parameter->getType()->isBuiltin()) {
-                    $parameterSignature['type'] = $parameter->getType()->getName();
+                $type = $parameter->getType();
+                if ($type && method_exists($type, 'isBuiltin') && !$type->isBuiltin()) {
+                    $parameterSignature['type'] = $type->getName();
                 }
                 if ($parameter->isDefaultValueAvailable()) {
                     $parameterSignature['default'] = $parameter->getDefaultValue();


### PR DESCRIPTION
## What/Why?
Reduce number of getType() calls in Bigcommerce\Injector\Reflection\ParameterInspector::getMethodSignature(). getType() seems to be quite expensive, per my (artificial) benchmarks, this reduces the latency of Injector::create() by ~30%. Even if it's less in actual applications, it's still worth making this change

## Rollout/Rollback
Merge / revert

## Testing
Tests still pass