### PR TITLE
Micro-optimisation in ArrayServiceCache::get() and ArrayServiceCache::remove()

### DIFF
--- a/src/Cache/ArrayServiceCache.php
+++ b/src/Cache/ArrayServiceCache.php
@@ -31,10 +31,7 @@ class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface
      */
     public function get(string $key): mixed
     {
-        if (!isset($this->values[$key])) {
-            return false;
-        }
-        return $this->values[$key];
+        return $this->values[$key] ?? false;
     }
 
     /**
@@ -57,9 +54,6 @@ class ArrayServiceCache implements ServiceCacheInterface, MultiGetCacheInterface
      */
     public function remove(string $key): void
     {
-        if (!isset($this->values[$key])) {
-            return;
-        }
         unset($this->values[$key]);
     }
 


### PR DESCRIPTION
## What/Why?
Micro-optimisation in ArrayServiceCache::get() and ArrayServiceCache::remove()
- null-coalescing is 6% faster than the previous logic per my rudimentary benchmarks
- When we remove an element, it's likely set. And isset() isn't necessary to avoid warnings when unset()ing non-existent array elements

It's a micro-optimisation but I was already here so figured I'd commit the change

## Rollout/Rollback
Merge / revert

## Testing
Tests still pass